### PR TITLE
feat: adding url encoding for username password in connection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 
 	"github.com/Trendyol/go-pq-cdc/logger"
@@ -35,11 +36,17 @@ type LoggerConfig struct {
 }
 
 func (c *Config) DSN() string {
-	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?replication=database", c.Username, c.Password, c.Host, c.Port, c.Database)
+	// URL-encode username and password to handle special characters
+	encodedUsername := url.QueryEscape(c.Username)
+	encodedPassword := url.QueryEscape(c.Password)
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?replication=database", encodedUsername, encodedPassword, c.Host, c.Port, c.Database)
 }
 
 func (c *Config) DSNWithoutSSL() string {
-	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", c.Username, c.Password, c.Host, c.Port, c.Database)
+	// URL-encode username and password to handle special characters
+	encodedUsername := url.QueryEscape(c.Username)
+	encodedPassword := url.QueryEscape(c.Password)
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", encodedUsername, encodedPassword, c.Host, c.Port, c.Database)
 }
 
 func (c *Config) SetDefault() {


### PR DESCRIPTION
When I try to connect to postgres database by password which has special characters in it (for example **asd23pq£**), I am not able to connect it. 

So, I have added query escape within DSN method. 

please check @3n0ugh