### PR TITLE
fix: handle keep alive messages correctly

### DIFF
--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -213,6 +213,10 @@ func (s *stream) sink(ctx context.Context) {
 				logger.Error("decode primary keepalive message", "error", errPKM)
 				continue
 			}
+			if pkm.ServerWALEnd > 0 {
+				s.UpdateXLogPos(pkm.ServerWALEnd)
+				logger.Debug("updated xlog position from keepalive", "serverWALEnd", pkm.ServerWALEnd.String())
+			}
 			if pkm.ReplyRequested {
 				if err = SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos())); err != nil {
 					logger.Error("standby status update", "error", err)


### PR DESCRIPTION
related to https://github.com/Trendyol/go-pq-cdc/issues/81

PostgreSQL sends PrimaryKeepaliveMessage after all data messages for a given WAL position have been sent. The ServerWALEnd in the keepalive represents a safe position to acknowledge, even if no actual data changes were received (e.g., empty transactions, DDL-only changes, etc.).

This directly solves issue #81 - when catching up from a historical position, keepalives will properly advance confirmed_flush_lsn even before user code calls Ack().