### PR TITLE
feat: add REPLICA IDENTITY NOTHING / USING INDEX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ func Handler(ctx *replication.ListenerContext) {
 * [Streaming Transactions](./example/streaming-transactions)
 * [Snapshot Mode (Initial Data Capture)](./example/snapshot-initial-mode)
 * [Snapshot Only Mode (One-Time Export)](./example/snapshot-only-mode)
+* [Replica Identity Using Index](./example/replica-identity-using-index)
+* [Replica Identity Nothing](./example/replica-identity-nothing)
 * [PostgreSQL to Elasticsearch](https://github.com/Trendyol/go-pq-cdc-elasticsearch/tree/main/example/simple)
 * [PostgreSQL to Kafka](https://github.com/Trendyol/go-pq-cdc-kafka/tree/main/example/simple)
 * [PostgreSQL to PostgreSQL](./example/postgresql)
@@ -264,6 +266,12 @@ For large tables, `REPLICA IDENTITY USING INDEX` can be a better trade-off for n
 - `USING INDEX` sends only old values of the columns from the selected unique index (`K` tuple data).
 - This reduces payload size, but unlike `FULL`, old non-index columns are not available.
 
+You can run [Replica Identity Using Index](./example/replica-identity-using-index) for a minimal `USING INDEX` setup.
+
+`REPLICA IDENTITY NOTHING` is best paired with insert-only publications because PostgreSQL does not provide old-row data for updates and deletes in that mode.
+
+You can run [Replica Identity Nothing](./example/replica-identity-nothing) for an insert-only `NOTHING` example.
+
 ### Configuration
 
 | Variable                                |   Type   | Required | Default | Description                                                                                           | Options                                                                                                                                            |
@@ -375,4 +383,3 @@ Import the grafana dashboard [json file](./grafana/dashboard.json).
 | Date taking effect | Version | Change | How to check |
 |--------------------|---------|--------|--------------| 
 | -                  | -       | -      | -            |
-

--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ This requires setting the table's replica identity to FULL:
 - In that mode, old tuple values (including TOASTed fields) are not provided.
 - Therefore, `FULL` is required to correctly handle TOASTed columns in CDC.
 
+For large tables, `REPLICA IDENTITY USING INDEX` can be a better trade-off for network traffic and matching performance:
+
+- `FULL` sends old values of all columns (`O` tuple data).
+- `USING INDEX` sends only old values of the columns from the selected unique index (`K` tuple data).
+- This reduces payload size, but unlike `FULL`, old non-index columns are not available.
+
 ### Configuration
 
 | Variable                                |   Type   | Required | Default | Description                                                                                           | Options                                                                                                                                            |
@@ -275,7 +281,8 @@ This requires setting the table's replica identity to FULL:
 | `publication.operations`                | []string |   yes    |    -    | Set PostgreSQL publication operations. List of operations to track; all or a subset can be specified. | **INSERT:** Track insert operations. <br> **UPDATE:** Track update operations. <br> **DELETE:** Track delete operations.                           |
 | `publication.tables`                    | []Table  |   yes    |    -    | Set tables which are tracked by data change capture                                                   | Define multiple tables as needed.                                                                                                                  |
 | `publication.tables[i].name`            |  string  |   yes    |    -    | Set the data change captured table name                                                               | Must be a valid table name in the specified database.                                                                                              |
-| `publication.tables[i].replicaIdentity` |  string  |   yes    |    -    | Set the data change captured table replica identity [`FULL`, `DEFAULT`]                               | **FULL:** Captures all columns when a row is updated or deleted. <br> **DEFAULT:** Captures only the primary key when a row is updated or deleted. |
+| `publication.tables[i].replicaIdentity` |  string  |   yes    |    -    | Set the data change captured table replica identity [`DEFAULT`, `FULL`, `NOTHING`, `USING INDEX`]     | **DEFAULT:** Captures primary key old values. <br> **FULL:** Captures all old row columns. <br> **NOTHING:** Captures no old row data (typically insert-only scenarios; update/delete matching can fail). <br> **USING INDEX:** Captures old values from a chosen unique index. |
+| `publication.tables[i].replicaIdentityIndex` |  string  |    no*   |    -    | Unique index name used when `replicaIdentity` is `USING INDEX`.                                        | Required only for `USING INDEX`, ignored otherwise.                                                   |
 | `publication.tables[i].schema`          |  string  |    no    | public  | Set the data change captured table schema name                                                        | Must be a valid table name in the specified database.                                                                                              |
 | `publication.tables[i].columns`                   | []string |    no    |   -   | Only include these columns in replication and snapshotting                                            | Must not be set when `replicaIdentity` is `FULL`; only compatible with `DEFAULT`.                                                                 |
 | `publication.tables[i].partitioned`               |   bool   |    no    | false | Flag for replicating a partitioned table via the root table name instead of listing out the individual table parts. Sets `publish_via_partition_root = true` when creating the publication. | Only avaible with PostgreSQL 13+. This is a publication-wide setting, Setting any table with this will include it for all tables in the publication.                                                                                                                                                   |

--- a/example/replica-identity-nothing/docker-compose.yml
+++ b/example/replica-identity-nothing/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3"
+services:
+  postgres:
+    image: postgres:16.2
+    environment:
+      POSTGRES_DB: cdc_db
+      POSTGRES_USER: cdc_user
+      POSTGRES_PASSWORD: cdc_pass
+    ports:
+      - "5433:5432"
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+      - -c
+      - max_replication_slots=20
+      - -c
+      - max_wal_senders=25
+      - -c
+      - max_connections=100
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cdc_user -d cdc_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/example/replica-identity-nothing/init.sql
+++ b/example/replica-identity-nothing/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE events (
+   id serial PRIMARY KEY,
+   event_key text NOT NULL,
+   payload jsonb NOT NULL
+);

--- a/example/replica-identity-nothing/main.go
+++ b/example/replica-identity-nothing/main.go
@@ -72,8 +72,7 @@ func main() {
 }
 
 func handler(ctx *replication.ListenerContext) {
-	switch msg := ctx.Message.(type) {
-	case *format.Insert:
+	if msg, ok := ctx.Message.(*format.Insert); ok {
 		slog.Info("insert message received", "new", msg.Decoded)
 	}
 

--- a/example/replica-identity-nothing/main.go
+++ b/example/replica-identity-nothing/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	cdc "github.com/Trendyol/go-pq-cdc"
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/Trendyol/go-pq-cdc/pq/publication"
+	"github.com/Trendyol/go-pq-cdc/pq/replication"
+	"github.com/Trendyol/go-pq-cdc/pq/slot"
+)
+
+/*
+	cd example/replica-identity-nothing
+
+	docker compose up -d
+	go run .
+
+	psql "postgres://cdc_user:cdc_pass@127.0.0.1:5433/cdc_db"
+
+	INSERT INTO events (event_key, payload) VALUES ('signup', '{"user":"alice"}');
+*/
+
+func main() {
+	ctx := context.Background()
+
+	cfg := config.Config{
+		Host:      "127.0.0.1",
+		Port:      5433,
+		Username:  "cdc_user",
+		Password:  "cdc_pass",
+		Database:  "cdc_db",
+		DebugMode: false,
+		Publication: publication.Config{
+			CreateIfNotExists: true,
+			Name:              "cdc_publication",
+			Operations: publication.Operations{
+				publication.OperationInsert,
+			},
+			Tables: publication.Tables{
+				{
+					Name:            "events",
+					Schema:          "public",
+					ReplicaIdentity: publication.ReplicaIdentityNothing,
+				},
+			},
+		},
+		Slot: slot.Config{
+			CreateIfNotExists:           true,
+			Name:                        "cdc_slot",
+			SlotActivityCheckerInterval: 3000,
+		},
+		Metric: config.MetricConfig{
+			Port: 8081,
+		},
+		Logger: config.LoggerConfig{
+			LogLevel: slog.LevelInfo,
+		},
+	}
+
+	connector, err := cdc.NewConnector(ctx, cfg, handler)
+	if err != nil {
+		slog.Error("new connector", "error", err)
+		os.Exit(1)
+	}
+
+	defer connector.Close()
+	connector.Start(ctx)
+}
+
+func handler(ctx *replication.ListenerContext) {
+	switch msg := ctx.Message.(type) {
+	case *format.Insert:
+		slog.Info("insert message received", "new", msg.Decoded)
+	}
+
+	if err := ctx.Ack(); err != nil {
+		slog.Error("ack", "error", err)
+	}
+}

--- a/example/replica-identity-using-index/docker-compose.yml
+++ b/example/replica-identity-using-index/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3"
+services:
+  postgres:
+    image: postgres:16.2
+    environment:
+      POSTGRES_DB: cdc_db
+      POSTGRES_USER: cdc_user
+      POSTGRES_PASSWORD: cdc_pass
+    ports:
+      - "5433:5432"
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+      - -c
+      - max_replication_slots=20
+      - -c
+      - max_wal_senders=25
+      - -c
+      - max_connections=100
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cdc_user -d cdc_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/example/replica-identity-using-index/init.sql
+++ b/example/replica-identity-using-index/init.sql
@@ -1,0 +1,7 @@
+CREATE TABLE users (
+   id serial PRIMARY KEY,
+   email text NOT NULL,
+   name text NOT NULL
+);
+
+CREATE UNIQUE INDEX users_email_unique_idx ON users (email);

--- a/example/replica-identity-using-index/main.go
+++ b/example/replica-identity-using-index/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	cdc "github.com/Trendyol/go-pq-cdc"
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/Trendyol/go-pq-cdc/pq/publication"
+	"github.com/Trendyol/go-pq-cdc/pq/replication"
+	"github.com/Trendyol/go-pq-cdc/pq/slot"
+)
+
+/*
+	cd example/replica-identity-using-index
+
+	docker compose up -d
+	go run .
+
+	psql "postgres://cdc_user:cdc_pass@127.0.0.1:5433/cdc_db"
+
+	INSERT INTO users (email, name) VALUES ('alice@example.com', 'Alice');
+	UPDATE users SET name = 'Alice Updated' WHERE email = 'alice@example.com';
+	DELETE FROM users WHERE email = 'alice@example.com';
+*/
+
+func main() {
+	ctx := context.Background()
+
+	cfg := config.Config{
+		Host:      "127.0.0.1",
+		Port:      5433,
+		Username:  "cdc_user",
+		Password:  "cdc_pass",
+		Database:  "cdc_db",
+		DebugMode: false,
+		Publication: publication.Config{
+			CreateIfNotExists: true,
+			Name:              "cdc_publication",
+			Operations: publication.Operations{
+				publication.OperationInsert,
+				publication.OperationUpdate,
+				publication.OperationDelete,
+			},
+			Tables: publication.Tables{
+				{
+					Name:                 "users",
+					Schema:               "public",
+					ReplicaIdentity:      publication.ReplicaIdentityUsingIndex,
+					ReplicaIdentityIndex: "users_email_unique_idx",
+				},
+			},
+		},
+		Slot: slot.Config{
+			CreateIfNotExists:           true,
+			Name:                        "cdc_slot",
+			SlotActivityCheckerInterval: 3000,
+		},
+		Metric: config.MetricConfig{
+			Port: 8081,
+		},
+		Logger: config.LoggerConfig{
+			LogLevel: slog.LevelInfo,
+		},
+	}
+
+	connector, err := cdc.NewConnector(ctx, cfg, handler)
+	if err != nil {
+		slog.Error("new connector", "error", err)
+		os.Exit(1)
+	}
+
+	defer connector.Close()
+	connector.Start(ctx)
+}
+
+func handler(ctx *replication.ListenerContext) {
+	switch msg := ctx.Message.(type) {
+	case *format.Insert:
+		slog.Info("insert message received", "new", msg.Decoded)
+	case *format.Update:
+		slog.Info(
+			"update message received",
+			"oldTupleType", string(rune(msg.OldTupleType)),
+			"new", msg.NewDecoded,
+			"old", msg.OldDecoded,
+		)
+	case *format.Delete:
+		slog.Info("delete message received", "old", msg.OldDecoded)
+	}
+
+	if err := ctx.Ack(); err != nil {
+		slog.Error("ack", "error", err)
+	}
+}

--- a/integration_test/system_identity_full_test.go
+++ b/integration_test/system_identity_full_test.go
@@ -3,20 +3,23 @@ package integration
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	cdc "github.com/Trendyol/go-pq-cdc"
 	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/Trendyol/go-pq-cdc/pq/message/format"
 	"github.com/Trendyol/go-pq-cdc/pq/publication"
 	"github.com/Trendyol/go-pq-cdc/pq/replication"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReplicaIdentityDefault(t *testing.T) {
 	ctx := context.Background()
 
-	cdcCfg := Config
+	cdcCfg := cloneConnectorConfig()
 	cdcCfg.Slot.Name = "slot_test_replica_identity_default"
 	cdcCfg.Publication.Tables[0].ReplicaIdentity = publication.ReplicaIdentityDefault
 
@@ -89,7 +92,7 @@ func TestReplicaIdentityDefault(t *testing.T) {
 func TestReplicaIdentityFull(t *testing.T) {
 	ctx := context.Background()
 
-	cdcCfg := Config
+	cdcCfg := cloneConnectorConfig()
 	cdcCfg.Slot.Name = "slot_test_replica_identity_full"
 	cdcCfg.Publication.Tables[0].ReplicaIdentity = publication.ReplicaIdentityFull
 
@@ -157,4 +160,233 @@ func TestReplicaIdentityFull(t *testing.T) {
 			}
 		})
 	})
+}
+
+func TestReplicaIdentityNothing(t *testing.T) {
+	ctx := context.Background()
+
+	cdcCfg := cloneConnectorConfig()
+	cdcCfg.Slot.Name = "slot_test_replica_identity_nothing"
+	cdcCfg.Publication.Operations = publication.Operations{publication.OperationInsert}
+	cdcCfg.Publication.Tables[0].ReplicaIdentity = publication.ReplicaIdentityNothing
+
+	forEachProtoVersion(t, cdcCfg, func(t *testing.T, cdcCfg config.Config) {
+		postgresConn, err := newPostgresConn()
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		if !assert.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg)) {
+			t.FailNow()
+		}
+
+		handlerFunc := func(ctx *replication.ListenerContext) {
+			_ = ctx.Ack()
+		}
+
+		_, err = cdc.NewConnector(ctx, cdcCfg, handlerFunc)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		t.Cleanup(func() {
+			assert.NoError(t, RestoreDB(ctx))
+			assert.NoError(t, postgresConn.Close(ctx))
+		})
+
+		replicaIdentity, replicaIdentityIndex := getReplicaIdentity(ctx, t, postgresConn, "public", "books")
+		assert.Equal(t, publication.ReplicaIdentityNothing, replicaIdentity)
+		assert.Empty(t, replicaIdentityIndex)
+	})
+}
+
+func TestReplicaIdentityUsingIndex(t *testing.T) {
+	ctx := context.Background()
+
+	cdcCfg := cloneConnectorConfig()
+	cdcCfg.Slot.Name = "slot_test_replica_identity_using_index"
+	cdcCfg.Publication.Tables[0].ReplicaIdentity = publication.ReplicaIdentityUsingIndex
+	cdcCfg.Publication.Tables[0].ReplicaIdentityIndex = "books_name_unique_idx"
+
+	forEachProtoVersion(t, cdcCfg, func(t *testing.T, cdcCfg config.Config) {
+		postgresConn, err := newPostgresConn()
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		if !assert.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg)) {
+			t.FailNow()
+		}
+
+		err = pgExec(ctx, postgresConn, "CREATE UNIQUE INDEX books_name_unique_idx ON public.books(name);")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		handlerFunc := func(ctx *replication.ListenerContext) {
+			_ = ctx.Ack()
+		}
+
+		_, err = cdc.NewConnector(ctx, cdcCfg, handlerFunc)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		t.Cleanup(func() {
+			assert.NoError(t, RestoreDB(ctx))
+			assert.NoError(t, postgresConn.Close(ctx))
+		})
+
+		replicaIdentity, replicaIdentityIndex := getReplicaIdentity(ctx, t, postgresConn, "public", "books")
+		assert.Equal(t, publication.ReplicaIdentityUsingIndex, replicaIdentity)
+		assert.Equal(t, "books_name_unique_idx", replicaIdentityIndex)
+	})
+}
+
+func TestReplicaIdentityUsingIndexUpdateUsesKeyTuple(t *testing.T) {
+	ctx := context.Background()
+
+	cdcCfg := cloneConnectorConfig()
+	cdcCfg.Slot.Name = "slot_test_replica_identity_using_index_key_tuple"
+	cdcCfg.Publication.Tables[0].ReplicaIdentity = publication.ReplicaIdentityUsingIndex
+	cdcCfg.Publication.Tables[0].ReplicaIdentityIndex = "books_name_unique_idx"
+
+	forEachProtoVersion(t, cdcCfg, func(t *testing.T, cdcCfg config.Config) {
+		postgresConn, err := newPostgresConn()
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		if !assert.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg)) {
+			t.FailNow()
+		}
+
+		err = pgExec(ctx, postgresConn, "CREATE UNIQUE INDEX books_name_unique_idx ON public.books(name);")
+		require.NoError(t, err)
+
+		updates := make(chan *format.Update, 5)
+		handlerFunc := func(ctx *replication.ListenerContext) {
+			if msg, ok := ctx.Message.(*format.Update); ok {
+				updates <- msg
+			}
+			_ = ctx.Ack()
+		}
+
+		connector, err := cdc.NewConnector(ctx, cdcCfg, handlerFunc)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			connector.Close()
+			assert.NoError(t, RestoreDB(ctx))
+			assert.NoError(t, postgresConn.Close(ctx))
+		})
+
+		go connector.Start(ctx)
+
+		waitCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		require.NoError(t, connector.WaitUntilReady(waitCtx))
+		cancel()
+
+		err = pgExec(ctx, postgresConn, "INSERT INTO books(id, name) VALUES(1, 'book-old');")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		err = pgExec(ctx, postgresConn, "UPDATE books SET name = 'book-new' WHERE id = 1;")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		select {
+		case msg := <-updates:
+			assert.Equal(t, uint8(format.UpdateTupleTypeKey), msg.OldTupleType)
+			assert.NotNil(t, msg.OldDecoded)
+			assert.Len(t, msg.OldDecoded, 2)
+			assert.Nil(t, msg.OldDecoded["id"])
+			assert.Equal(t, "book-old", msg.OldDecoded["name"])
+			assert.NotNil(t, msg.NewDecoded)
+			assert.Len(t, msg.NewDecoded, 2)
+			assert.Equal(t, int32(1), msg.NewDecoded["id"])
+			assert.Equal(t, "book-new", msg.NewDecoded["name"])
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for update message")
+		}
+	})
+}
+
+func TestReplicaIdentityUsingIndexMissingIndexReturnsError(t *testing.T) {
+	ctx := context.Background()
+
+	cdcCfg := cloneConnectorConfig()
+	cdcCfg.Slot.Name = "slot_test_replica_identity_using_index_missing_index"
+	cdcCfg.Publication.Tables[0].ReplicaIdentity = publication.ReplicaIdentityUsingIndex
+	cdcCfg.Publication.Tables[0].ReplicaIdentityIndex = "books_name_unique_idx_missing"
+
+	forEachProtoVersion(t, cdcCfg, func(t *testing.T, cdcCfg config.Config) {
+		postgresConn, err := newPostgresConn()
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		if !assert.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg)) {
+			t.FailNow()
+		}
+
+		t.Cleanup(func() {
+			assert.NoError(t, RestoreDB(ctx))
+			assert.NoError(t, postgresConn.Close(ctx))
+		})
+
+		handlerFunc := func(ctx *replication.ListenerContext) {
+			_ = ctx.Ack()
+		}
+
+		_, err = cdc.NewConnector(ctx, cdcCfg, handlerFunc)
+		if assert.Error(t, err) {
+			assert.ErrorContains(t, err, "does not exist")
+			assert.ErrorContains(t, err, "books_name_unique_idx_missing")
+		}
+	})
+}
+
+func getReplicaIdentity(ctx context.Context, t *testing.T, conn pq.Connection, schema, table string) (string, string) {
+	t.Helper()
+
+	query := fmt.Sprintf(`
+		SELECT c.relreplident, idx.relname
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		LEFT JOIN pg_index i ON i.indrelid = c.oid AND i.indisreplident
+		LEFT JOIN pg_class idx ON idx.oid = i.indexrelid
+		WHERE n.nspname = '%s' AND c.relname = '%s'
+	`, schema, table)
+
+	resultReader := conn.Exec(ctx, query)
+	results, err := resultReader.ReadAll()
+	if !assert.NoError(t, err) {
+		_ = resultReader.Close()
+		t.FailNow()
+	}
+
+	if !assert.NoError(t, resultReader.Close()) {
+		t.FailNow()
+	}
+
+	if len(results) == 0 || len(results[0].Rows) == 0 {
+		t.Fatalf("replica identity row not found for %s.%s", schema, table)
+	}
+
+	row := results[0].Rows[0]
+	if len(row) < 2 {
+		t.Fatalf("unexpected row length for replica identity query")
+	}
+
+	return publication.ReplicaIdentityMap[string(row[0])], string(row[1])
+}
+
+func cloneConnectorConfig() config.Config {
+	cfg := Config
+	cfg.Publication.Operations = append(publication.Operations(nil), Config.Publication.Operations...)
+	cfg.Publication.Tables = append(publication.Tables(nil), Config.Publication.Tables...)
+	return cfg
 }

--- a/pq/publication/operation.go
+++ b/pq/publication/operation.go
@@ -51,3 +51,7 @@ func (ops Operations) String() string {
 
 	return strings.Join(res, ", ")
 }
+
+func (ops Operations) Contains(op Operation) bool {
+	return slices.Contains(ops, op)
+}

--- a/pq/publication/replica_identity.go
+++ b/pq/publication/replica_identity.go
@@ -96,7 +96,7 @@ func (c *Publication) GetReplicaIdentities(ctx context.Context) ([]Table, error)
 	tableNames := make([]string, len(c.cfg.Tables))
 
 	for i, t := range c.cfg.Tables {
-		tableNames[i] = quoteLiteral(qualifiedTableName(t))
+		tableNames[i] = pq.QuoteLiteral(qualifiedTableName(t))
 	}
 
 	query := fmt.Sprintf(`
@@ -199,8 +199,4 @@ func qualifiedTableName(t Table) string {
 	}
 
 	return t.Schema + "." + t.Name
-}
-
-func quoteLiteral(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }

--- a/pq/publication/replica_identity_test.go
+++ b/pq/publication/replica_identity_test.go
@@ -1,0 +1,45 @@
+package publication
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapReplicaIdentity(t *testing.T) {
+	t.Run("should map postgres relreplident codes", func(t *testing.T) {
+		assert.Equal(t, ReplicaIdentityDefault, mapReplicaIdentity(int32('d')))
+		assert.Equal(t, ReplicaIdentityFull, mapReplicaIdentity(int32('f')))
+		assert.Equal(t, ReplicaIdentityNothing, mapReplicaIdentity(int32('n')))
+		assert.Equal(t, ReplicaIdentityUsingIndex, mapReplicaIdentity(int32('i')))
+	})
+
+	t.Run("should handle string values", func(t *testing.T) {
+		assert.Equal(t, ReplicaIdentityDefault, mapReplicaIdentity("d"))
+		assert.Equal(t, ReplicaIdentityUsingIndex, mapReplicaIdentity("i"))
+	})
+
+	t.Run("should return raw code for unknown values", func(t *testing.T) {
+		assert.Equal(t, "x", mapReplicaIdentity("x"))
+		assert.Equal(t, "x", mapReplicaIdentity(int32('x')))
+	})
+}
+
+func TestQualifiedTableName(t *testing.T) {
+	t.Run("should use explicit schema", func(t *testing.T) {
+		assert.Equal(t, "custom.books", qualifiedTableName(Table{Schema: "custom", Name: "books"}))
+	})
+
+	t.Run("should use schema from dotted table name", func(t *testing.T) {
+		assert.Equal(t, "custom.books", qualifiedTableName(Table{Name: "custom.books"}))
+	})
+
+	t.Run("should default to public schema", func(t *testing.T) {
+		assert.Equal(t, "public.books", qualifiedTableName(Table{Name: "books"}))
+	})
+}
+
+func TestQuoteLiteral(t *testing.T) {
+	assert.Equal(t, "'simple'", quoteLiteral("simple"))
+	assert.Equal(t, "'o''reilly'", quoteLiteral("o'reilly"))
+}

--- a/pq/publication/replica_identity_test.go
+++ b/pq/publication/replica_identity_test.go
@@ -38,8 +38,3 @@ func TestQualifiedTableName(t *testing.T) {
 		assert.Equal(t, "public.books", qualifiedTableName(Table{Name: "books"}))
 	})
 }
-
-func TestQuoteLiteral(t *testing.T) {
-	assert.Equal(t, "'simple'", quoteLiteral("simple"))
-	assert.Equal(t, "'o''reilly'", quoteLiteral("o'reilly"))
-}

--- a/pq/publication/table.go
+++ b/pq/publication/table.go
@@ -31,9 +31,10 @@ var ValidSnapshotPartitionStrategies = []SnapshotPartitionStrategy{
 }
 
 type Table struct {
-	Name            string `json:"name" yaml:"name"`
-	ReplicaIdentity string `json:"replicaIdentity" yaml:"replicaIdentity"`
-	Schema          string `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Name                 string `json:"name" yaml:"name"`
+	ReplicaIdentity      string `json:"replicaIdentity" yaml:"replicaIdentity"`
+	ReplicaIdentityIndex string `json:"replicaIdentityIndex,omitempty" yaml:"replicaIdentityIndex,omitempty"`
+	Schema               string `json:"schema,omitempty" yaml:"schema,omitempty"`
 	// SnapshotPartitionStrategy allows overriding the auto-detected partition strategy.
 	// Useful when integer PKs are hash-based (not sequential) and range partitioning performs poorly.
 	// Options: "" (auto), "integer_range", "ctid_block", "offset"
@@ -54,6 +55,14 @@ func (tc Table) Validate() error {
 
 	if tc.ReplicaIdentity == ReplicaIdentityFull && len(tc.Columns) > 0 {
 		return errors.New("cannot specify columns when replica identity is FULL. Must be ReplicaIdentityDefault")
+	}
+
+	if tc.ReplicaIdentity == ReplicaIdentityUsingIndex {
+		if strings.TrimSpace(tc.ReplicaIdentityIndex) == "" {
+			return errors.New("replicaIdentityIndex cannot be empty when replicaIdentity is USING INDEX")
+		}
+	} else if strings.TrimSpace(tc.ReplicaIdentityIndex) != "" {
+		return errors.New("replicaIdentityIndex can only be set when replicaIdentity is USING INDEX")
 	}
 
 	return nil
@@ -80,12 +89,11 @@ func (ts Tables) Diff(tss Tables) Tables {
 	tssMap := make(map[string]Table)
 
 	for _, t := range tss {
-		tssMap[t.Name+t.ReplicaIdentity] = t
+		tssMap[t.Schema+"."+t.Name] = t
 	}
 
 	for _, t := range ts {
-		v, found := tssMap[t.Name+t.ReplicaIdentity]
-		if !found || v.ReplicaIdentity != t.ReplicaIdentity || !slices.Equal(v.Columns, t.Columns) || v.Partitioned != t.Partitioned {
+		if v, found := tssMap[t.Schema+"."+t.Name]; !found || v.ReplicaIdentity != t.ReplicaIdentity || v.ReplicaIdentityIndex != t.ReplicaIdentityIndex || !slices.Equal(v.Columns, t.Columns) || v.Partitioned != t.Partitioned {
 			res = append(res, t)
 		}
 	}

--- a/pq/publication/table_test.go
+++ b/pq/publication/table_test.go
@@ -1,0 +1,101 @@
+package publication
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableValidateReplicaIdentityIndex(t *testing.T) {
+	t.Run("should allow using index with index name", func(t *testing.T) {
+		table := Table{
+			Name:                 "books",
+			Schema:               "public",
+			ReplicaIdentity:      ReplicaIdentityUsingIndex,
+			ReplicaIdentityIndex: "books_name_unique_idx",
+		}
+
+		require.NoError(t, table.Validate())
+	})
+
+	t.Run("should reject using index without index name", func(t *testing.T) {
+		table := Table{
+			Name:            "books",
+			Schema:          "public",
+			ReplicaIdentity: ReplicaIdentityUsingIndex,
+		}
+
+		err := table.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "replicaIdentityIndex cannot be empty")
+	})
+
+	t.Run("should reject index name when identity is not using index", func(t *testing.T) {
+		table := Table{
+			Name:                 "books",
+			Schema:               "public",
+			ReplicaIdentity:      ReplicaIdentityDefault,
+			ReplicaIdentityIndex: "books_name_unique_idx",
+		}
+
+		err := table.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "replicaIdentityIndex can only be set")
+	})
+}
+
+func TestTablesDiffReplicaIdentityIndex(t *testing.T) {
+	current := Tables{
+		{
+			Name:                 "books",
+			Schema:               "public",
+			ReplicaIdentity:      ReplicaIdentityUsingIndex,
+			ReplicaIdentityIndex: "books_name_unique_idx",
+		},
+	}
+
+	t.Run("should include table when replica identity index changes", func(t *testing.T) {
+		desired := Tables{
+			{
+				Name:                 "books",
+				Schema:               "public",
+				ReplicaIdentity:      ReplicaIdentityUsingIndex,
+				ReplicaIdentityIndex: "books_name_other_idx",
+			},
+		}
+
+		diff := desired.Diff(current)
+		require.Len(t, diff, 1)
+		assert.Equal(t, "books_name_other_idx", diff[0].ReplicaIdentityIndex)
+	})
+
+	t.Run("should not include table when identity and index are equal", func(t *testing.T) {
+		desired := Tables{
+			{
+				Name:                 "books",
+				Schema:               "public",
+				ReplicaIdentity:      ReplicaIdentityUsingIndex,
+				ReplicaIdentityIndex: "books_name_unique_idx",
+			},
+		}
+
+		diff := desired.Diff(current)
+		require.Empty(t, diff)
+	})
+
+	t.Run("should include table when switching from using index to default", func(t *testing.T) {
+		desired := Tables{
+			{
+				Name:            "books",
+				Schema:          "public",
+				ReplicaIdentity: ReplicaIdentityDefault,
+			},
+		}
+
+		diff := desired.Diff(current)
+		require.Len(t, diff, 1)
+		assert.Equal(t, ReplicaIdentityDefault, diff[0].ReplicaIdentity)
+		assert.Empty(t, diff[0].ReplicaIdentityIndex)
+	})
+}


### PR DESCRIPTION
### Summary

This MR adds full support for PostgreSQL replica identity modes `NOTHING` and `USING INDEX`, in addition to existing `DEFAULT` and `FULL`.

The change includes config support, validation, SQL execution changes, reconciliation/diff improvements, docs, and tests.

### Background

Before this MR, table-level replica identity configuration supported only `DEFAULT` and `FULL`.  
Issue #49 asks for support for the remaining PostgreSQL modes:

- `NOTHING`
- `USING INDEX`

These modes are important for workloads that want to reduce old-row payload size and use index-based key tuples for update/delete replication messages.

### What Changed

#### 1) Config model and validation

- Added `ReplicaIdentityIndex` to `publication.Table`.
- Extended supported identity options with `NOTHING` and `USING INDEX`.
- Added validation rules:
  - `ReplicaIdentityIndex` is required when identity is `USING INDEX`.
  - `ReplicaIdentityIndex` must be empty for all other identity modes.

#### 2) Replica identity execution and reconciliation

- Added mapping support for PostgreSQL `relreplident` codes: `d`, `f`, `n`, `i`.
- Updated `AlterTableReplicaIdentity(...)` to:
  - quote identifiers
  - emit `REPLICA IDENTITY USING INDEX <index>` for `USING INDEX`
- Updated `GetReplicaIdentities(...)` to fetch both:
  - replica identity mode (`relreplident`)
  - replica identity index (`pg_index.indisreplident` join)
- Updated table diff logic to include `ReplicaIdentityIndex`.

#### 3) Operational safety/logging

- Added a warning path when table identity is `NOTHING` while publication operations include `UPDATE` or `DELETE`.
- Added `Operations.Contains(...)` helper used by the warning check.

#### 4) Documentation updates

- Expanded README config docs for:
  - supported replica identity values: `DEFAULT`, `FULL`, `NOTHING`, `USING INDEX`
  - new `publication.tables[i].replicaIdentityIndex` field
- Added explanation of tuple behavior/trade-off:
  - `FULL` -> old tuple data (`O`)
  - `USING INDEX` -> key tuple data (`K`)

### Behavior Matrix

| Mode | Old-row data on UPDATE/DELETE | Notes |
|---|---|---|
| `DEFAULT` | Primary key old values | Existing behavior |
| `FULL` | Full old row (`O`) | Existing behavior |
| `NOTHING` | No old tuple | Usually suitable for insert-only patterns |
| `USING INDEX` | Index key tuple (`K`) | Lower payload, requires configured replica identity index |

### Test Coverage

#### Unit tests

- `pq/publication/table_test.go`
  - validates `ReplicaIdentityIndex` rules
  - verifies diff behavior when index changes
- `pq/publication/replica_identity_test.go`
  - verifies relreplident mapping (`d/f/n/i`)
  - verifies unknown-code fallback behavior
  - verifies helper behavior for table naming and literal quoting

#### Integration tests

Updated `integration_test/system_identity_full_test.go` with:

- `TestReplicaIdentityNothing`
- `TestReplicaIdentityUsingIndex`
- `TestReplicaIdentityUsingIndexUpdateUsesKeyTuple`
- `TestReplicaIdentityUsingIndexMissingIndexReturnsError`

### Backward Compatibility

- No behavior change for existing `DEFAULT` and `FULL` configurations.
- New functionality is opt-in.
- Misconfigurations for `USING INDEX` now fail early with explicit errors.

### Risk Assessment

- `USING INDEX` relies on valid PostgreSQL index constraints; invalid/missing index cases are covered with integration tests.
- `NOTHING` with UPDATE/DELETE is allowed by design but now emits warning logs to make the trade-off explicit.
- Identifier quoting and safer literal construction reduce malformed SQL/query risk.