### PR TITLE
fix: prevent WAL position from being confirmed before handler acknowledgment

### DIFF
--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -63,6 +63,7 @@ type stream struct {
 	mu                  *sync.RWMutex
 	config              config.Config
 	lastXLogPos         pq.LSN
+	confirmedXLogPos    pq.LSN
 	snapshotLSN         pq.LSN
 	openFromSnapshotLSN bool
 	closed              atomic.Bool
@@ -292,7 +293,7 @@ func (s *stream) sinkLoop(ctx context.Context, buf *messageBuffer, streamBuf *st
 			}
 			if pgconn.Timeout(err) {
 				if s.LoadXLogPos() > 0 {
-					if err = SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos())); err != nil {
+					if err = SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos())); err != nil {
 						logger.Error("send stand by status update", "error", err)
 						return true
 					}
@@ -355,7 +356,7 @@ func (s *stream) handleKeepalive(ctx context.Context, data []byte) error {
 	}
 
 	if pkm.ReplyRequested {
-		if err = SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos())); err != nil {
+		if err = SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos())); err != nil {
 			logger.Error("standby status update", "error", err)
 			return err
 		}
@@ -454,9 +455,9 @@ func (s *stream) process(ctx context.Context) {
 
 		ackFunc := func() error {
 			pos := pq.LSN(msg.walStart)
-			s.UpdateXLogPos(pos)
-			logger.Debug("send stand by status update", "xLogPos", s.LoadXLogPos().String())
-			return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()))
+			s.UpdateConfirmedXLogPos(pos)
+			logger.Debug("send stand by status update", "xLogPos", s.LoadConfirmedXLogPos().String())
+			return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos()))
 		}
 
 		if s.isHeartbeatMessage(msg.message) {
@@ -548,6 +549,21 @@ func (s *stream) LoadXLogPos() pq.LSN {
 	return s.lastXLogPos
 }
 
+func (s *stream) UpdateConfirmedXLogPos(l pq.LSN) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.confirmedXLogPos < l {
+		s.confirmedXLogPos = l
+	}
+}
+
+func (s *stream) LoadConfirmedXLogPos() pq.LSN {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.confirmedXLogPos
+}
+
 func (s *stream) OpenFromSnapshotLSN() {
 	s.openFromSnapshotLSN = true
 }
@@ -626,12 +642,12 @@ func (s *stream) fetchSnapshotLSN(ctx context.Context) (pq.LSN, error) {
 	return snapshotLSN, nil
 }
 
-func SendStandbyStatusUpdate(_ context.Context, conn pq.Connection, walWritePosition uint64) error {
+func SendStandbyStatusUpdate(_ context.Context, conn pq.Connection, walReceivedPosition, walFlushedPosition uint64) error {
 	data := make([]byte, 0, 34)
 	data = append(data, StandbyStatusUpdateByteID)
-	data = AppendUint64(data, walWritePosition)
-	data = AppendUint64(data, walWritePosition)
-	data = AppendUint64(data, walWritePosition)
+	data = AppendUint64(data, walReceivedPosition)
+	data = AppendUint64(data, walFlushedPosition)
+	data = AppendUint64(data, walFlushedPosition)
 	data = AppendUint64(data, timeToPgTime(time.Now()))
 	data = append(data, 0)
 


### PR DESCRIPTION
related issue #107 

**Problem**

- When a CDC handler panics or fails before calling Ack(), the consumed message is permanently lost. On restart, PostgreSQL does not redeliver it because confirmed_flush_lsn has already advanced past that message.

**Root cause**: A single field (lastXLogPos) was used to track both the server's latest WAL position (received via keepalive messages) and the client's confirmed flush position (set via explicit Ack()). Keepalive messages from PostgreSQL continuously update lastXLogPos to serverWALEnd, and periodic standby status updates send this value back as confirmed_flush_lsn — regardless of whether the handler has actually processed the message.

**How it happens**

  1. Sink goroutine receives WAL data (Begin, Relation, Insert, Commit) and a keepalive
  2. Keepalive updates lastXLogPos to the server's latest WAL end position
  3. Process goroutine picks up a buffered message (e.g. Relation), handler falls through to Ack(), which sends lastXLogPos (already advanced by keepalive) as the confirmed flush position
  4. Process goroutine picks up the Insert message, handler panics
  5. PostgreSQL has already recorded the advanced confirmed_flush_lsn — the Insert is gone

**Solution**

Separate the two concerns into distinct fields:

  - lastXLogPos — tracks the server WAL end position from keepalive messages (what we've received)
  - confirmedXLogPos — tracks the position explicitly confirmed by the user via Ack() (what we've processed)

  The standby status update now sends these as different protocol fields:
  - walWrite = lastXLogPos (keeps the connection alive)
  - walFlush / walApply = confirmedXLogPos (controls where replication restarts from)

  This ensures confirmed_flush_lsn only advances when the handler explicitly calls Ack(). If the handler panics or crashes before acknowledgment, the message will be redelivered on restart.

  Test plan

  - All existing tests pass (go test ./...)
  - Manual verification: start CDC, insert a row with a panicking handler, restart — message should be redelivered