### PR TITLE
chore:bump-go-version-to-1.24 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.4'
+          go-version: '1.24'
 
       - name: Lint
         run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.4'
+          go-version: '1.24'
 
       - name: Install dependencies
         run: make tidy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.4'
+          go-version: '1.24'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,14 @@
-linters-settings:
-  funlen:
-    lines: 100
+version: "2"
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
     - errorlint
-    - exportloopref
     - funlen
     - gocheckcompilerdirectives
     - gochecknoinits
@@ -18,11 +16,8 @@ linters:
     - gocritic
     - gocyclo
     - godox
-    - gofmt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -31,17 +26,25 @@ linters:
     - nolintlint
     - revive
     - staticcheck
-    - stylecheck
     - testifylint
     - unconvert
     - unparam
     - unused
     - whitespace
 
-issues:
-  exclude-rules:
-    - path: (.+)_test.go
-      linters:
-        - funlen
-        - goconst
-        - dupl
+  settings:
+    funlen:
+      lines: 100
+
+  exclusions:
+    rules:
+      - path: (.+)_test.go
+        linters:
+          - funlen
+          - goconst
+          - dupl
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ init: init/lint
 
 .PHONY: init/lint  init/vulnCheck
 init/lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
-	go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@v0.22.0
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+	go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@v0.44.0
 
 .PHONY: init/vulnCheck
 init/vulnCheck:
@@ -25,7 +25,7 @@ audit: vendor
 .PHONY: tidy
 tidy:
 	@echo 'Tidying and verifying module dependencies...'
-	go mod tidy -compat=1.22.4
+	go mod tidy -compat=1.24
 	go mod verify
 
 .PHONY: tidy/all

--- a/benchmark/benchmark_cdc/go-pq-cdc-kafka/Dockerfile
+++ b/benchmark/benchmark_cdc/go-pq-cdc-kafka/Dockerfile
@@ -1,5 +1,5 @@
 #- Build Stage
-FROM --platform=linux/arm64 golang:1.23-alpine3.19 AS builder
+FROM --platform=linux/arm64 golang:1.24-alpine AS builder
 
 # Install git (required for go mod download)
 RUN apk add --no-cache git

--- a/benchmark/benchmark_cdc/go-pq-cdc-kafka/go.mod
+++ b/benchmark/benchmark_cdc/go-pq-cdc-kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/Trendyol/go-pq-cdc/benchmark/go-pq-cdc-kafka
 
-go 1.22.4
+go 1.24
 
 replace github.com/Trendyol/go-pq-cdc => ../../../
 

--- a/benchmark/benchmark_initial/go-pq-cdc-kafka/Dockerfile
+++ b/benchmark/benchmark_initial/go-pq-cdc-kafka/Dockerfile
@@ -1,5 +1,5 @@
 #- Build Stage
-FROM --platform=linux/arm64 golang:1.23-alpine3.19 AS builder
+FROM --platform=linux/arm64 golang:1.24-alpine AS builder
 
 # Install git (required for go mod download)
 RUN apk add --no-cache git

--- a/benchmark/benchmark_initial/go-pq-cdc-kafka/go.mod
+++ b/benchmark/benchmark_initial/go-pq-cdc-kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/Trendyol/go-pq-cdc/benchmark/go-pq-cdc-kafka
 
-go 1.22.4
+go 1.24
 
 replace github.com/Trendyol/go-pq-cdc => ../../../
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,4 @@
+// Package config provides configuration types and helpers for the PostgreSQL CDC connector.
 package config
 
 import (
@@ -16,6 +17,7 @@ import (
 
 const defaultSchema = "public"
 
+// Config holds the PostgreSQL connection and CDC pipeline configuration.
 type Config struct {
 	Heartbeat        HeartbeatConfig    `json:"heartbeat" yaml:"heartbeat"`
 	Logger           LoggerConfig       `json:"logger" yaml:"logger"`
@@ -32,19 +34,23 @@ type Config struct {
 	ExtensionSupport ExtensionSupport   `json:"extensionSupport" yaml:"extensionSupport"`
 }
 
+// MetricConfig holds the Prometheus metrics server configuration.
 type MetricConfig struct {
 	Port int `json:"port" yaml:"port"`
 }
 
+// LoggerConfig holds the logging configuration, supporting a custom logger or slog level.
 type LoggerConfig struct {
 	Logger   logger.Logger `json:"-" yaml:"-"`         // custom logger
 	LogLevel slog.Level    `json:"level" yaml:"level"` // if custom logger is nil, set the slog log level
 }
 
+// ExtensionSupport configures PostgreSQL extension compatibility flags.
 type ExtensionSupport struct {
 	EnableTimeScaleDB bool `json:"enableTimeScaleDB" yaml:"EnableTimeScaleDB"`
 }
 
+// HeartbeatConfig configures periodic writes to a heartbeat table to advance replication lag.
 type HeartbeatConfig struct {
 	Table    publication.Table `json:"table" yaml:"table"`
 	Interval time.Duration     `json:"interval" yaml:"interval"`
@@ -62,10 +68,12 @@ func (c *Config) ReplicationDSN() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?replication=database", url.QueryEscape(c.Username), url.QueryEscape(c.Password), c.Host, c.Port, c.Database)
 }
 
+// DSNWithoutSSL returns a PostgreSQL connection string with SSL explicitly disabled.
 func (c *Config) DSNWithoutSSL() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", url.QueryEscape(c.Username), url.QueryEscape(c.Password), c.Host, c.Port, c.Database)
 }
 
+// SetDefault populates zero-valued fields with sensible defaults.
 func (c *Config) SetDefault() {
 	if c.Port == 0 {
 		c.Port = 5432
@@ -200,6 +208,7 @@ func (c *Config) validateSnapshotSubset(pubTables publication.Tables) (publicati
 	return validatedTables, nil
 }
 
+// Validate checks all required fields and sub-configurations for correctness.
 func (c *Config) Validate() error {
 	var err error
 	if isEmpty(c.Host) {
@@ -243,10 +252,11 @@ func (c *Config) Validate() error {
 	return err
 }
 
+// Print logs the current configuration as JSON with the password masked.
 func (c *Config) Print() {
 	cfg := *c
 	cfg.Password = "*******"
-	b, _ := json.Marshal(cfg)
+	b, _ := json.Marshal(cfg) //nolint:gosec // G117: password is already masked above
 	fmt.Println("used config: " + string(b))
 }
 
@@ -278,6 +288,7 @@ func (c *Config) mergePublicationTableConfig(pubInfoTables publication.Tables) p
 	return result
 }
 
+// SnapshotConfig controls the initial data snapshot behavior before CDC streaming begins.
 type SnapshotConfig struct {
 	Mode              SnapshotMode       `json:"mode" yaml:"mode"`
 	InstanceID        string             `json:"instanceId" yaml:"instanceId"`
@@ -290,6 +301,7 @@ type SnapshotConfig struct {
 	Resnapshot        bool               `json:"resnapshot" yaml:"resnapshot"`
 }
 
+// Validate checks that snapshot settings are consistent and all required fields are set.
 func (s *SnapshotConfig) Validate() error {
 	if !s.Enabled {
 		return nil
@@ -326,10 +338,14 @@ func (s *SnapshotConfig) Validate() error {
 	return nil
 }
 
+// SnapshotMode determines when and how the initial data snapshot is taken.
 type SnapshotMode string
 
 const (
-	SnapshotModeInitial      SnapshotMode = "initial"
-	SnapshotModeNever        SnapshotMode = "never"
+	// SnapshotModeInitial takes a snapshot before starting CDC streaming.
+	SnapshotModeInitial SnapshotMode = "initial"
+	// SnapshotModeNever skips the snapshot and starts CDC streaming immediately.
+	SnapshotModeNever SnapshotMode = "never"
+	// SnapshotModeSnapshotOnly takes a snapshot without starting CDC streaming.
 	SnapshotModeSnapshotOnly SnapshotMode = "snapshot_only"
 )

--- a/config/read.go
+++ b/config/read.go
@@ -8,8 +8,9 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// ReadConfigYAML reads and parses a YAML configuration file into a Config.
 func ReadConfigYAML(path string) (Config, error) {
-	b, err := os.ReadFile(path)
+	b, err := os.ReadFile(path) //nolint:gosec // G304: path is caller-controlled, not user input
 	if err != nil {
 		return Config{}, errors.Wrap(err, "read yaml config")
 	}
@@ -24,8 +25,9 @@ func ReadConfigYAML(path string) (Config, error) {
 	return c, nil
 }
 
+// ReadConfigJSON reads and parses a JSON configuration file into a Config.
 func ReadConfigJSON(path string) (Config, error) {
-	b, err := os.ReadFile(path)
+	b, err := os.ReadFile(path) //nolint:gosec // G304: path is caller-controlled, not user input
 	if err != nil {
 		return Config{}, errors.Wrap(err, "read json config")
 	}

--- a/connector.go
+++ b/connector.go
@@ -1,3 +1,4 @@
+// Package cdc provides the main entry point for PostgreSQL CDC (Change Data Capture) connectors.
 package cdc
 
 import (
@@ -30,6 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// Connector defines the interface for managing a PostgreSQL CDC connection lifecycle.
 type Connector interface {
 	Start(ctx context.Context)
 	WaitUntilReady(ctx context.Context) error
@@ -53,6 +55,7 @@ type connector struct {
 	once               sync.Once
 }
 
+// NewConnectorWithConfigFile creates a new Connector by loading configuration from a JSON or YAML file.
 func NewConnectorWithConfigFile(ctx context.Context, configFilePath string, listenerFunc replication.ListenerFunc) (Connector, error) {
 	var cfg config.Config
 	var err error
@@ -72,6 +75,7 @@ func NewConnectorWithConfigFile(ctx context.Context, configFilePath string, list
 	return NewConnector(ctx, cfg, listenerFunc)
 }
 
+// NewConnector creates a new Connector with the given configuration and listener function.
 func NewConnector(ctx context.Context, cfg config.Config, listenerFunc replication.ListenerFunc) (Connector, error) {
 	cfg.SetDefault()
 	if err := cfg.Validate(); err != nil {
@@ -100,7 +104,7 @@ func NewConnector(ctx context.Context, cfg config.Config, listenerFunc replicati
 	if cfg.IsHeartbeatEnabled() {
 		hb = heartbeat.New(cfg.DSN(), cfg.Heartbeat)
 		if err := hb.EnsureTable(ctx, conn); err != nil {
-			conn.Close(ctx)
+			_ = conn.Close(ctx)
 			return nil, errors.Wrap(err, "create heartbeat table")
 		}
 	}
@@ -112,7 +116,7 @@ func NewConnector(ctx context.Context, cfg config.Config, listenerFunc replicati
 	logger.Info("publication", "info", publicationInfo)
 
 	// Close the setup connection - we don't need it anymore
-	conn.Close(ctx)
+	_ = conn.Close(ctx)
 
 	m := metric.NewMetric(cfg.Slot.Name)
 

--- a/example/partitioned-table-mapping/main.go
+++ b/example/partitioned-table-mapping/main.go
@@ -1,3 +1,4 @@
+// Package main demonstrates CDC with partitioned table mapping and publish_via_partition_root.
 package main
 
 import (

--- a/example/postgresql/go.mod
+++ b/example/postgresql/go.mod
@@ -1,6 +1,6 @@
 module github.com/Trendyol/go-pq-cdc/example/postgresql
 
-go 1.22.4
+go 1.24
 
 replace github.com/Trendyol/go-pq-cdc => ../..
 

--- a/example/replica-identity-nothing/main.go
+++ b/example/replica-identity-nothing/main.go
@@ -1,3 +1,4 @@
+// Package main demonstrates CDC with REPLICA IDENTITY NOTHING tables.
 package main
 
 import (

--- a/example/replica-identity-using-index/main.go
+++ b/example/replica-identity-using-index/main.go
@@ -1,3 +1,4 @@
+// Package main demonstrates CDC with REPLICA IDENTITY USING INDEX tables.
 package main
 
 import (

--- a/example/simple-column-filtering/main.go
+++ b/example/simple-column-filtering/main.go
@@ -1,3 +1,4 @@
+// Package main demonstrates CDC with publication column filtering.
 package main
 
 import (

--- a/example/simple-file-config/go.mod
+++ b/example/simple-file-config/go.mod
@@ -1,6 +1,6 @@
 module github.com/Trendyol/go-pq-cdc/example/simple-file-config
 
-go 1.22.4
+go 1.24
 
 replace github.com/Trendyol/go-pq-cdc => ../..
 

--- a/example/simple-with-heartbeat/main.go
+++ b/example/simple-with-heartbeat/main.go
@@ -1,3 +1,4 @@
+// Package main demonstrates CDC with heartbeat enabled to prevent WAL bloat on low-traffic databases.
 package main
 
 import (

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -1,3 +1,4 @@
+// Package main demonstrates a simple CDC setup with PostgreSQL logical replication.
 package main
 
 import (

--- a/example/snapshot-ctid-partitioning/main.go
+++ b/example/snapshot-ctid-partitioning/main.go
@@ -1,3 +1,4 @@
+// Package main demonstrates CDC snapshot with CTID block partitioning and explicit partition strategy configuration.
 package main
 
 import (

--- a/example/snapshot-initial-mode/main.go
+++ b/example/snapshot-initial-mode/main.go
@@ -1,17 +1,19 @@
+// Package main demonstrates CDC snapshot in initial mode, which snapshots existing data before streaming changes.
 package main
 
 import (
 	"context"
+	"log"
+	"log/slog"
+	"os"
+	"time"
+
 	cdc "github.com/Trendyol/go-pq-cdc"
 	"github.com/Trendyol/go-pq-cdc/config"
 	"github.com/Trendyol/go-pq-cdc/pq/message/format"
 	"github.com/Trendyol/go-pq-cdc/pq/publication"
 	"github.com/Trendyol/go-pq-cdc/pq/replication"
 	"github.com/Trendyol/go-pq-cdc/pq/slot"
-	"log"
-	"log/slog"
-	"os"
-	"time"
 )
 
 func main() {

--- a/example/snapshot-only-mode/main.go
+++ b/example/snapshot-only-mode/main.go
@@ -1,16 +1,18 @@
+// Package main demonstrates CDC snapshot in snapshot-only mode, which captures existing data without streaming changes.
 package main
 
 import (
 	"context"
+	"log"
+	"log/slog"
+	"os"
+	"time"
+
 	cdc "github.com/Trendyol/go-pq-cdc"
 	"github.com/Trendyol/go-pq-cdc/config"
 	"github.com/Trendyol/go-pq-cdc/pq/message/format"
 	"github.com/Trendyol/go-pq-cdc/pq/publication"
 	"github.com/Trendyol/go-pq-cdc/pq/replication"
-	"log"
-	"log/slog"
-	"os"
-	"time"
 )
 
 func main() {

--- a/example/snapshot-with-scaling/Dockerfile
+++ b/example/snapshot-with-scaling/Dockerfile
@@ -1,5 +1,5 @@
 #- Build Stage
-FROM --platform=linux/arm64 golang:1.23-alpine3.19 AS builder
+FROM --platform=linux/arm64 golang:1.24-alpine AS builder
 
 # Install git (required for go mod download)
 RUN apk add --no-cache git

--- a/example/snapshot-with-scaling/go.mod
+++ b/example/snapshot-with-scaling/go.mod
@@ -1,6 +1,6 @@
 module basic-snapshot-with-scaling
 
-go 1.22.4
+go 1.24
 
 replace github.com/Trendyol/go-pq-cdc => ../../
 

--- a/example/streaming-transactions/go.mod
+++ b/example/streaming-transactions/go.mod
@@ -1,6 +1,6 @@
 module github.com/Trendyol/go-pq-cdc/example/streaming-transactions
 
-go 1.22.4
+go 1.24
 
 replace github.com/Trendyol/go-pq-cdc => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Trendyol/go-pq-cdc
 
-go 1.22.4
+go 1.24
 
 require (
 	github.com/avast/retry-go/v4 v4.6.0

--- a/integration_test/go.mod
+++ b/integration_test/go.mod
@@ -1,6 +1,6 @@
 module github.com/Trendyol/go-pq-cdc/integration
 
-go 1.22.4
+go 1.24
 
 replace github.com/Trendyol/go-pq-cdc => ../
 

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -1,3 +1,4 @@
+// Package http provides an HTTP server for metrics, health checks, and replication slot info.
 package http
 
 import (
@@ -16,10 +17,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// SlotInfoProvider retrieves replication slot information from PostgreSQL.
 type SlotInfoProvider interface {
 	Info(ctx context.Context) (*slot.Info, error)
 }
 
+// Server defines the interface for the CDC HTTP server.
 type Server interface {
 	Listen()
 	Shutdown()
@@ -32,6 +35,7 @@ type server struct {
 	closed           bool
 }
 
+// NewServer creates a new HTTP server with metrics, status, and slot info endpoints.
 func NewServer(cfg config.Config, registry metric.Registry, slotInfoProvider SlotInfoProvider) Server {
 	s := &server{
 		cdcConfig:        cfg,

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -1,3 +1,4 @@
+// Package metric provides Prometheus metrics for CDC replication and snapshot monitoring.
 package metric
 
 import (
@@ -11,6 +12,7 @@ const (
 	replicationSlotSubsystem = "replication_slot"
 )
 
+// Metric defines methods for recording CDC replication and snapshot metrics.
 type Metric interface {
 	InsertOpIncrement(count int64)
 	UpdateOpIncrement(count int64)
@@ -63,6 +65,8 @@ type metric struct {
 	snapshotActiveWorkers   prometheus.Gauge
 }
 
+// NewMetric creates a new Metric instance with Prometheus collectors for the given slot.
+//
 //nolint:funlen
 func NewMetric(slotName string) Metric {
 	hostname, _ := os.Hostname()

--- a/internal/metric/registry.go
+++ b/internal/metric/registry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 )
 
+// Registry manages Prometheus metric collector registration.
 type Registry interface {
 	AddMetricCollectors(metricCollectors ...prometheus.Collector)
 	Prometheus() *prometheus.Registry
@@ -16,6 +17,7 @@ type prometheusRegistry struct {
 	registry *prometheus.Registry
 }
 
+// NewRegistry creates a new Prometheus registry with default and CDC metric collectors.
 func NewRegistry(m Metric) Registry {
 	r := prometheus.NewRegistry()
 	r.MustRegister(collectors.NewBuildInfoCollector())

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,3 +1,4 @@
+// Package retry provides configurable retry logic for CDC operations.
 package retry
 
 import (
@@ -6,21 +7,25 @@ import (
 	"github.com/avast/retry-go/v4"
 )
 
+// DefaultOptions defines the default retry behavior with a fixed one-second delay.
 var DefaultOptions = []retry.Option{
 	retry.LastErrorOnly(true),
 	retry.Delay(time.Second),
 	retry.DelayType(retry.FixedDelay),
 }
 
+// Config holds retry options and an optional error filter for retryable operations.
 type Config[T any] struct {
 	If      func(err error) bool
 	Options []retry.Option
 }
 
+// Do executes the given function with the configured retry options.
 func (rc Config[T]) Do(f retry.RetryableFuncWithData[T]) (T, error) {
 	return retry.DoWithData(f, rc.Options...)
 }
 
+// OnErrorConfig creates a retry Config that retries up to attemptCount times when check returns true.
 func OnErrorConfig[T any](attemptCount uint, check func(error) bool) Config[T] {
 	cfg := Config[T]{
 		If:      check,

--- a/internal/slice/slice.go
+++ b/internal/slice/slice.go
@@ -1,5 +1,7 @@
+// Package slice provides utility functions for slice type conversions.
 package slice
 
+// ConvertToInt converts a byte slice to an int slice.
 func ConvertToInt(ss []byte) []int {
 	r := make([]int, len(ss))
 	for i, s := range ss {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,3 +1,4 @@
+// Package logger provides a pluggable logging interface for the CDC library.
 package logger
 
 import (
@@ -8,6 +9,7 @@ import (
 
 var _default Logger
 
+// Logger defines the interface for structured logging at multiple levels.
 type Logger interface {
 	Debug(msg string, args ...any)
 	Info(msg string, args ...any)
@@ -17,28 +19,34 @@ type Logger interface {
 
 var once sync.Once
 
+// InitLogger sets the global logger instance; it can only be called once.
 func InitLogger(l Logger) {
 	once.Do(func() {
 		_default = l
 	})
 }
 
+// Debug logs a message at debug level using the global logger.
 func Debug(msg string, args ...any) {
 	_default.Debug(msg, args...)
 }
 
+// Info logs a message at info level using the global logger.
 func Info(msg string, args ...any) {
 	_default.Info(msg, args...)
 }
 
+// Warn logs a message at warn level using the global logger.
 func Warn(msg string, args ...any) {
 	_default.Warn(msg, args...)
 }
 
+// Error logs a message at error level using the global logger.
 func Error(msg string, args ...any) {
 	_default.Error(msg, args...)
 }
 
+// NewSlog creates a new Logger backed by slog with JSON output at the given level.
 func NewSlog(logLevel slog.Level) Logger {
 	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel}))
 }

--- a/pq/connection.go
+++ b/pq/connection.go
@@ -1,3 +1,4 @@
+// Package pq provides PostgreSQL connection and replication primitives.
 package pq
 
 import (
@@ -9,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgproto3"
 )
 
+// Connection defines the interface for PostgreSQL connections.
 type Connection interface {
 	Connect(ctx context.Context) error
 	IsClosed() bool
@@ -23,6 +25,7 @@ type connection struct {
 	dsn string
 }
 
+// NewConnection creates and opens a new PostgreSQL connection.
 func NewConnection(ctx context.Context, dsn string) (Connection, error) {
 	conn := NewConnectionTemplate(dsn)
 	if err := conn.Connect(ctx); err != nil {
@@ -31,6 +34,7 @@ func NewConnection(ctx context.Context, dsn string) (Connection, error) {
 	return conn, nil
 }
 
+// NewConnectionTemplate creates a connection without opening it.
 func NewConnectionTemplate(dsn string) Connection {
 	return &connection{
 		dsn: dsn,

--- a/pq/heartbeat/heartbeat.go
+++ b/pq/heartbeat/heartbeat.go
@@ -1,3 +1,4 @@
+// Package heartbeat provides periodic heartbeat updates to a PostgreSQL table to prevent WAL bloat.
 package heartbeat
 
 import (

--- a/pq/heartbeat/heartbeat.go
+++ b/pq/heartbeat/heartbeat.go
@@ -40,7 +40,6 @@ func (h *Heartbeat) EnsureTable(ctx context.Context, conn pq.Connection) error {
 	schema := quoteIdentifier(h.cfg.Table.Schema)
 	table := quoteIdentifier(h.cfg.Table.Name)
 	constraint := quoteIdentifier(h.cfg.Table.Name + "_single_row")
-
 	createTableSQL := fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s.%s (
 			id INTEGER PRIMARY KEY DEFAULT 1,

--- a/pq/lsn.go
+++ b/pq/lsn.go
@@ -6,12 +6,14 @@ import (
 	"github.com/go-playground/errors"
 )
 
+// LSN represents a PostgreSQL Log Sequence Number.
 type LSN uint64
 
 func (lsn LSN) String() string {
-	return fmt.Sprintf("%X/%X", uint32(lsn>>32), uint32(lsn))
+	return fmt.Sprintf("%X/%X", uint32(lsn>>32), uint32(lsn)) //nolint:gosec // G115: intentional truncation for LSN formatting
 }
 
+// ParseLSN parses a PostgreSQL LSN string in the format "X/X".
 func ParseLSN(s string) (LSN, error) {
 	var upperHalf, lowerHalf uint64
 	var nparsed int

--- a/pq/message/format/begin.go
+++ b/pq/message/format/begin.go
@@ -1,18 +1,22 @@
+// Package format defines the decoded logical replication message types for PostgreSQL CDC.
 package format
 
 import (
 	"encoding/binary"
+	"time"
+
 	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/go-playground/errors"
-	"time"
 )
 
+// Begin represents a decoded logical replication BEGIN message.
 type Begin struct {
 	CommitTime time.Time
 	FinalLSN   pq.LSN
 	Xid        uint32
 }
 
+// NewBegin parses raw bytes into a Begin message.
 func NewBegin(data []byte) (*Begin, error) {
 	msg := &Begin{}
 	if err := msg.decode(data); err != nil {
@@ -30,7 +34,7 @@ func (b *Begin) decode(data []byte) error {
 
 	b.FinalLSN = pq.LSN(binary.BigEndian.Uint64(data[skipByte:]))
 	skipByte += 8
-	b.CommitTime = time.Unix(int64(binary.BigEndian.Uint64(data[skipByte:])), 0)
+	b.CommitTime = time.Unix(int64(binary.BigEndian.Uint64(data[skipByte:])), 0) //nolint:gosec // G115: PG timestamp fits int64
 	skipByte += 8
 	b.Xid = binary.BigEndian.Uint32(data[skipByte:])
 

--- a/pq/message/format/commit.go
+++ b/pq/message/format/commit.go
@@ -2,11 +2,13 @@ package format
 
 import (
 	"encoding/binary"
+	"time"
+
 	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/go-playground/errors"
-	"time"
 )
 
+// Commit represents a decoded logical replication COMMIT message.
 type Commit struct {
 	CommitTime        time.Time
 	CommitLSN         pq.LSN
@@ -14,6 +16,7 @@ type Commit struct {
 	Flags             uint8
 }
 
+// NewCommit parses raw bytes into a Commit message.
 func NewCommit(data []byte) (*Commit, error) {
 	msg := &Commit{}
 	if err := msg.decode(data); err != nil {
@@ -35,7 +38,7 @@ func (c *Commit) decode(data []byte) error {
 	skipByte += 8
 	c.TransactionEndLSN = pq.LSN(binary.BigEndian.Uint64(data[skipByte:]))
 	skipByte += 8
-	c.CommitTime = time.Unix(int64(binary.BigEndian.Uint64(data[skipByte:])), 0)
+	c.CommitTime = time.Unix(int64(binary.BigEndian.Uint64(data[skipByte:])), 0) //nolint:gosec // G115: PG timestamp fits int64
 
 	return nil
 }

--- a/pq/message/format/delete.go
+++ b/pq/message/format/delete.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-playground/errors"
 )
 
+// Delete represents a decoded logical replication DELETE message.
 type Delete struct {
 	MessageTime    time.Time
 	OldTupleData   *tuple.Data
@@ -19,6 +20,7 @@ type Delete struct {
 	OldTupleType   uint8
 }
 
+// NewDelete parses raw bytes into a Delete message using the given relation map.
 func NewDelete(data []byte, streamedTransaction bool, relation map[uint32]*Relation, serverTime time.Time) (*Delete, error) {
 	msg := &Delete{
 		MessageTime: serverTime,

--- a/pq/message/format/insert.go
+++ b/pq/message/format/insert.go
@@ -8,10 +8,12 @@ import (
 	"github.com/go-playground/errors"
 )
 
+// InsertTupleDataType is the tuple data type marker for insert messages.
 const (
 	InsertTupleDataType = 'N'
 )
 
+// Insert represents a decoded logical replication INSERT message.
 type Insert struct {
 	MessageTime    time.Time
 	TupleData      *tuple.Data
@@ -22,6 +24,7 @@ type Insert struct {
 	XID            uint32
 }
 
+// NewInsert parses raw bytes into an Insert message using the given relation map.
 func NewInsert(data []byte, streamedTransaction bool, relation map[uint32]*Relation, serverTime time.Time) (*Insert, error) {
 	msg := &Insert{
 		MessageTime: serverTime,

--- a/pq/message/format/insert_test.go
+++ b/pq/message/format/insert_test.go
@@ -59,5 +59,5 @@ func TestInsert_New(t *testing.T) {
 		MessageTime:    now,
 	}
 
-	assert.EqualValues(t, expected, msg)
+	assert.Equal(t, expected, msg)
 }

--- a/pq/message/format/keepalive.go
+++ b/pq/message/format/keepalive.go
@@ -33,7 +33,7 @@ func (p *PrimaryKeepaliveMessage) decode(data []byte) error {
 	}
 
 	p.ServerWALEnd = pq.LSN(binary.BigEndian.Uint64(data))
-	p.ServerTime = pgTimeToTime(int64(binary.BigEndian.Uint64(data[8:])))
+	p.ServerTime = pgTimeToTime(int64(binary.BigEndian.Uint64(data[8:]))) //nolint:gosec // G115: PG timestamp fits int64
 	p.ReplyRequested = data[16] != 0
 	return nil
 }

--- a/pq/message/format/relation.go
+++ b/pq/message/format/relation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-playground/errors"
 )
 
+// Relation represents a decoded logical replication RELATION message describing a table schema.
 type Relation struct {
 	Namespace     string
 	Name          string
@@ -18,6 +19,7 @@ type Relation struct {
 	ReplicaID     uint8
 }
 
+// NewRelation parses raw bytes into a Relation message.
 func NewRelation(data []byte, streamedTransaction bool) (*Relation, error) {
 	msg := &Relation{}
 	if err := msg.decode(data, streamedTransaction); err != nil {

--- a/pq/message/format/snapshot.go
+++ b/pq/message/format/snapshot.go
@@ -9,6 +9,7 @@ import (
 // SnapshotEventType represents the type of snapshot event
 type SnapshotEventType string
 
+// Snapshot event type constants.
 const (
 	SnapshotEventTypeBegin SnapshotEventType = "BEGIN" // Snapshot started
 	SnapshotEventTypeData  SnapshotEventType = "DATA"  // Row data

--- a/pq/message/format/stream.go
+++ b/pq/message/format/stream.go
@@ -16,6 +16,7 @@ type StreamStart struct {
 	FirstSegment bool
 }
 
+// NewStreamStart parses raw bytes into a StreamStart message.
 func NewStreamStart(data []byte) (*StreamStart, error) {
 	// StreamStart message format:
 	// Byte1('S')  - message type (already at data[0])
@@ -43,6 +44,7 @@ type StreamAbort struct {
 	SubXid uint32
 }
 
+// NewStreamAbort parses raw bytes into a StreamAbort message.
 func NewStreamAbort(data []byte) (*StreamAbort, error) {
 	// StreamAbort message format:
 	// Byte1('A')  - message type (already at data[0])
@@ -70,6 +72,7 @@ type StreamCommit struct {
 	Flags             uint8
 }
 
+// NewStreamCommit parses raw bytes into a StreamCommit message.
 func NewStreamCommit(data []byte) (*StreamCommit, error) {
 	msg := &StreamCommit{}
 	if err := msg.decode(data); err != nil {
@@ -101,7 +104,7 @@ func (sc *StreamCommit) decode(data []byte) error {
 	skipByte += 8
 	sc.TransactionEndLSN = pq.LSN(binary.BigEndian.Uint64(data[skipByte:]))
 	skipByte += 8
-	sc.CommitTime = time.Unix(int64(binary.BigEndian.Uint64(data[skipByte:])), 0)
+	sc.CommitTime = time.Unix(int64(binary.BigEndian.Uint64(data[skipByte:])), 0) //nolint:gosec // G115: PG timestamp fits int64
 
 	return nil
 }

--- a/pq/message/format/update.go
+++ b/pq/message/format/update.go
@@ -8,12 +8,14 @@ import (
 	"github.com/go-playground/errors"
 )
 
+// Update tuple type markers for key, old, and new row data.
 const (
 	UpdateTupleTypeKey = 'K'
 	UpdateTupleTypeOld = 'O'
 	UpdateTupleTypeNew = 'N'
 )
 
+// Update represents a decoded logical replication UPDATE message.
 type Update struct {
 	MessageTime    time.Time
 	NewTupleData   *tuple.Data
@@ -27,6 +29,7 @@ type Update struct {
 	OldTupleType   uint8
 }
 
+// NewUpdate parses raw bytes into an Update message using the given relation map.
 func NewUpdate(data []byte, streamedTransaction bool, relation map[uint32]*Relation, serverTime time.Time) (*Update, error) {
 	msg := &Update{
 		MessageTime: serverTime,

--- a/pq/message/message.go
+++ b/pq/message/message.go
@@ -1,3 +1,4 @@
+// Package message decodes PostgreSQL logical replication messages by their leading byte identifier.
 package message
 
 import (
@@ -7,6 +8,7 @@ import (
 	"github.com/go-playground/errors"
 )
 
+// Logical replication message type byte identifiers.
 const (
 	StreamAbortByte  Type = 'A'
 	BeginByte        Type = 'B'
@@ -24,17 +26,21 @@ const (
 	StreamCommitByte Type = 'c'
 )
 
+// WAL-level message byte identifiers.
 const (
 	XLogDataByteID                = 'w'
 	PrimaryKeepaliveMessageByteID = 'k'
 )
 
+// ErrorByteNotSupported is returned when an unrecognized message type byte is encountered.
 var ErrorByteNotSupported = errors.New("message byte not supported")
 
+// Type is the single-byte identifier for a logical replication message.
 type Type uint8
 
 var streamedTransaction bool
 
+// New decodes raw WAL data into a typed logical replication message.
 func New(data []byte, serverTime time.Time, relation map[uint32]*format.Relation) (any, error) {
 	switch Type(data[0]) {
 	case BeginByte:

--- a/pq/message/tuple/data.go
+++ b/pq/message/tuple/data.go
@@ -1,3 +1,4 @@
+// Package tuple provides decoding for PostgreSQL logical replication tuple data.
 package tuple
 
 import (
@@ -7,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+// Tuple column data type markers.
 const (
 	DataTypeNull   = uint8('n')
 	DataTypeToast  = uint8('u')
@@ -16,20 +18,24 @@ const (
 
 var typeMap = pgtype.NewMap()
 
+// Data holds decoded tuple column data from a replication message.
 type Data struct {
 	Columns      DataColumns
 	SkipByte     int
 	ColumnNumber uint16
 }
 
+// DataColumns is a slice of decoded tuple columns.
 type DataColumns []*DataColumn
 
+// DataColumn represents a single column value in a tuple.
 type DataColumn struct {
 	Data     []byte
 	Length   uint32
 	DataType uint8
 }
 
+// RelationColumn describes a column in a relation message.
 type RelationColumn struct {
 	Name         string
 	DataType     uint32
@@ -37,6 +43,7 @@ type RelationColumn struct {
 	Flags        uint8
 }
 
+// NewData parses raw bytes into tuple Data starting at the given offset.
 func NewData(data []byte, tupleDataType uint8, skipByteLength int) (*Data, error) {
 	if data[skipByteLength] != tupleDataType {
 		return nil, errors.New("invalid tuple data type: " + string(data[skipByteLength]))
@@ -49,6 +56,7 @@ func NewData(data []byte, tupleDataType uint8, skipByteLength int) (*Data, error
 	return d, nil
 }
 
+// Decode reads column data from raw bytes starting at the given offset.
 func (d *Data) Decode(data []byte, skipByteLength int) {
 	d.ColumnNumber = binary.BigEndian.Uint16(data[skipByteLength:])
 	skipByteLength += 2
@@ -75,6 +83,7 @@ func (d *Data) Decode(data []byte, skipByteLength int) {
 	d.SkipByte = skipByteLength
 }
 
+// DecodeWithColumn decodes tuple columns into a name-value map using the relation schema.
 func (d *Data) DecodeWithColumn(columns []RelationColumn) (map[string]any, error) {
 	decoded := make(map[string]any, d.ColumnNumber)
 	for idx, col := range d.Columns {

--- a/pq/publication/config.go
+++ b/pq/publication/config.go
@@ -1,3 +1,4 @@
+// Package publication manages PostgreSQL publication configuration for logical replication.
 package publication
 
 import (
@@ -8,6 +9,7 @@ import (
 	"github.com/lib/pq"
 )
 
+// Config holds the configuration for a PostgreSQL publication.
 type Config struct {
 	Name              string     `json:"name" yaml:"name"`
 	Operations        Operations `json:"operations" yaml:"operations"`
@@ -15,6 +17,7 @@ type Config struct {
 	CreateIfNotExists bool       `json:"createIfNotExists" yaml:"createIfNotExists"`
 }
 
+// Validate checks the publication configuration for required fields and consistency.
 func (c Config) Validate() error {
 	var err error
 	if strings.TrimSpace(c.Name) == "" {

--- a/pq/publication/operation.go
+++ b/pq/publication/operation.go
@@ -7,8 +7,10 @@ import (
 	"github.com/go-playground/errors"
 )
 
+// OperationOptions lists all valid publication operations.
 var OperationOptions = Operations{"INSERT", "UPDATE", "DELETE", "TRUNCATE"}
 
+// Operation constants for publication DML event types.
 var (
 	OperationInsert   Operation = "INSERT"
 	OperationUpdate   Operation = "UPDATE"
@@ -16,8 +18,10 @@ var (
 	OperationTruncate Operation = "TRUNCATE"
 )
 
+// Operation represents a PostgreSQL publication DML operation type.
 type Operation string
 
+// Validate checks that the operation is one of the supported types.
 func (op Operation) Validate() error {
 	if !slices.Contains(OperationOptions, op) {
 		return errors.Newf("undefined operation. valid operations are: %v", OperationOptions)
@@ -26,8 +30,10 @@ func (op Operation) Validate() error {
 	return nil
 }
 
+// Operations is a slice of Operation values.
 type Operations []Operation
 
+// Validate checks that at least one operation is defined and all are valid.
 func (ops Operations) Validate() error {
 	if len(ops) == 0 {
 		return errors.New("at least one operation must be defined")
@@ -42,6 +48,7 @@ func (ops Operations) Validate() error {
 	return nil
 }
 
+// String returns a comma-separated list of operations.
 func (ops Operations) String() string {
 	res := make([]string, len(ops))
 
@@ -52,6 +59,7 @@ func (ops Operations) String() string {
 	return strings.Join(res, ", ")
 }
 
+// Contains reports whether ops includes the given operation.
 func (ops Operations) Contains(op Operation) bool {
 	return slices.Contains(ops, op)
 }

--- a/pq/publication/publication.go
+++ b/pq/publication/publication.go
@@ -12,21 +12,25 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+// ErrorPublicationIsNotExists is returned when a publication does not exist in the database.
 var (
 	ErrorPublicationIsNotExists = goerrors.New("publication is not exists")
 )
 
 var typeMap = pgtype.NewMap()
 
+// Publication manages a PostgreSQL logical replication publication.
 type Publication struct {
 	conn pq.Connection
 	cfg  Config
 }
 
+// New creates a new Publication with the given configuration and connection.
 func New(cfg Config, conn pq.Connection) *Publication {
 	return &Publication{cfg: cfg, conn: conn}
 }
 
+// Create creates the publication if it does not already exist and returns its configuration.
 func (c *Publication) Create(ctx context.Context) (*Config, error) {
 	info, err := c.Info(ctx)
 	if err != nil {
@@ -53,6 +57,7 @@ func (c *Publication) Create(ctx context.Context) (*Config, error) {
 	return &c.cfg, nil
 }
 
+// Info retrieves the current publication configuration from the database.
 func (c *Publication) Info(ctx context.Context) (*Config, error) {
 	resultReader := c.conn.Exec(ctx, c.cfg.infoQuery())
 	results, err := resultReader.ReadAll()

--- a/pq/publication/replica_identity.go
+++ b/pq/publication/replica_identity.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lib/pq"
 )
 
+// Replica identity modes for PostgreSQL logical replication.
 const (
 	ReplicaIdentityFull       = "FULL"
 	ReplicaIdentityDefault    = "DEFAULT"
@@ -20,9 +21,12 @@ const (
 )
 
 var (
-	ErrorTablesNotExists   = goerrors.New("table does not exists")
+	// ErrorTablesNotExists is returned when referenced tables do not exist in the database.
+	ErrorTablesNotExists = goerrors.New("table does not exists")
+	// ReplicaIdentityOptions lists all valid replica identity modes.
 	ReplicaIdentityOptions = []string{ReplicaIdentityDefault, ReplicaIdentityFull, ReplicaIdentityNothing, ReplicaIdentityUsingIndex}
-	ReplicaIdentityMap     = map[string]string{
+	// ReplicaIdentityMap maps PostgreSQL single-character codes to replica identity names.
+	ReplicaIdentityMap = map[string]string{
 		"d": ReplicaIdentityDefault,    // primary key on old value
 		"f": ReplicaIdentityFull,       // full row on old value
 		"n": ReplicaIdentityNothing,    // nothing on old value
@@ -30,6 +34,7 @@ var (
 	}
 )
 
+// SetReplicaIdentities applies configured replica identity settings to publication tables.
 func (c *Publication) SetReplicaIdentities(ctx context.Context) error {
 	if !c.cfg.CreateIfNotExists {
 		return nil
@@ -70,6 +75,7 @@ func (c *Publication) warnNothingReplicaIdentityWithUpdateDelete() {
 	}
 }
 
+// AlterTableReplicaIdentity changes the replica identity of the given table.
 func (c *Publication) AlterTableReplicaIdentity(ctx context.Context, t Table) error {
 	tableName := fmt.Sprintf("%s.%s", pq.QuoteIdentifier(t.Schema), pq.QuoteIdentifier(t.Name))
 	query := fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY %s;", tableName, t.ReplicaIdentity)
@@ -92,6 +98,7 @@ func (c *Publication) AlterTableReplicaIdentity(ctx context.Context, t Table) er
 	return nil
 }
 
+// GetReplicaIdentities retrieves the current replica identity settings for configured tables.
 func (c *Publication) GetReplicaIdentities(ctx context.Context) ([]Table, error) {
 	tableNames := make([]string, len(c.cfg.Tables))
 

--- a/pq/publication/table.go
+++ b/pq/publication/table.go
@@ -30,6 +30,7 @@ var ValidSnapshotPartitionStrategies = []SnapshotPartitionStrategy{
 	SnapshotPartitionStrategyOffset,
 }
 
+// Table represents a PostgreSQL table included in a publication.
 type Table struct {
 	Name                 string `json:"name" yaml:"name"`
 	ReplicaIdentity      string `json:"replicaIdentity" yaml:"replicaIdentity"`
@@ -44,6 +45,7 @@ type Table struct {
 	Partitioned bool `json:"partitioned,omitempty" yaml:"partitioned,omitempty"`
 }
 
+// Validate checks the table configuration for required fields and valid replica identity.
 func (tc Table) Validate() error {
 	if strings.TrimSpace(tc.Name) == "" {
 		return errors.New("table name cannot be empty")
@@ -68,8 +70,10 @@ func (tc Table) Validate() error {
 	return nil
 }
 
+// Tables is a slice of Table configurations.
 type Tables []Table
 
+// Validate checks that at least one table is defined and all tables are valid.
 func (ts Tables) Validate() error {
 	if len(ts) == 0 {
 		return errors.New("at least one table must be defined")
@@ -84,6 +88,7 @@ func (ts Tables) Validate() error {
 	return nil
 }
 
+// Diff returns tables that differ between ts and tss in identity, columns, or partitioning.
 func (ts Tables) Diff(tss Tables) Tables {
 	res := Tables{}
 	tssMap := make(map[string]Table)

--- a/pq/replication/replication.go
+++ b/pq/replication/replication.go
@@ -1,3 +1,4 @@
+// Package replication manages PostgreSQL logical replication connections, streaming, and WAL processing.
 package replication
 
 import (
@@ -12,14 +13,17 @@ import (
 	"github.com/jackc/pgx/v5/pgproto3"
 )
 
+// Replication manages a logical replication connection to PostgreSQL.
 type Replication struct {
 	conn pq.Connection
 }
 
+// New creates a new Replication instance with the given connection.
 func New(conn pq.Connection) *Replication {
 	return &Replication{conn: conn}
 }
 
+// Start begins logical replication from the given LSN using the specified slot and publication.
 func (r *Replication) Start(publicationName, slotName string, startLSN pq.LSN, protoVersion int) error {
 	pluginArguments := []string{
 		fmt.Sprintf("proto_version '%d'", protoVersion),
@@ -40,6 +44,7 @@ func (r *Replication) Start(publicationName, slotName string, startLSN pq.LSN, p
 	return nil
 }
 
+// Test validates the replication connection by processing the initial server response.
 func (r *Replication) Test(ctx context.Context) error {
 	var (
 		nextTli         int64

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -22,27 +22,33 @@ import (
 	"github.com/jackc/pgx/v5/pgproto3"
 )
 
+// Replication stream errors.
 var (
 	ErrorSlotInUse    = errors.New("replication slot in use")
 	ErrorNotConnected = errors.New("stream is not connected")
 )
 
+// StandbyStatusUpdateByteID is the byte identifier for standby status update messages.
 const (
 	StandbyStatusUpdateByteID = 'r'
 )
 
+// ListenerContext provides the decoded message and an Ack function to the listener callback.
 type ListenerContext struct {
 	Message any
 	Ack     func() error
 }
 
+// ListenerFunc is the callback invoked for each decoded replication message.
 type ListenerFunc func(ctx *ListenerContext)
 
+// Message pairs a decoded replication event with its WAL start position.
 type Message struct {
 	message  any
 	walStart int64
 }
 
+// Streamer defines the interface for managing a logical replication stream.
 type Streamer interface {
 	Connect(ctx context.Context) error
 	Open(ctx context.Context) error
@@ -69,6 +75,7 @@ type stream struct {
 	closed              atomic.Bool
 }
 
+// NewStream creates a new logical replication stream with the given configuration.
 func NewStream(dsn string, cfg config.Config, m metric.Metric, listenerFunc ListenerFunc) Streamer {
 	return &stream{
 		conn:         pq.NewConnectionTemplate(dsn),
@@ -180,7 +187,7 @@ func (b *messageBuffer) flushWithLSN(lsn pq.LSN) {
 	if b.pending != nil {
 		b.outCh <- &Message{
 			message:  b.pending.message,
-			walStart: int64(lsn),
+			walStart: int64(lsn), //nolint:gosec // G115: WAL LSN conversion is safe
 		}
 		b.pending = nil
 	}
@@ -246,7 +253,7 @@ func (s *streamTxBuffer) flushTx(xid uint32, outCh chan<- *Message, endLSN pq.LS
 		if i == n-1 {
 			outCh <- &Message{
 				message:  msg.message,
-				walStart: int64(endLSN),
+				walStart: int64(endLSN), //nolint:gosec // G115: WAL LSN conversion is safe
 			}
 		} else {
 			outCh <- msg
@@ -434,7 +441,7 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 		// DML event (Insert, Update, Delete, Relation, …)
 		m := &Message{
 			message:  decodedMsg,
-			walStart: int64(xld.WALStart),
+			walStart: int64(xld.WALStart), //nolint:gosec // G115: WAL LSN conversion is safe
 		}
 		if streamBuf.streaming {
 			streamBuf.append(m)
@@ -454,7 +461,7 @@ func (s *stream) process(ctx context.Context) {
 		}
 
 		ackFunc := func() error {
-			pos := pq.LSN(msg.walStart)
+			pos := pq.LSN(msg.walStart) //nolint:gosec // G115: WAL LSN conversion is safe
 			s.UpdateConfirmedXLogPos(pos)
 			logger.Debug("send stand by status update", "xLogPos", s.LoadConfirmedXLogPos().String())
 			return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos()))
@@ -583,7 +590,7 @@ func (s *stream) fetchSnapshotLSN(ctx context.Context) (pq.LSN, error) {
 			if err != nil {
 				return errors.Wrap(err, "create connection for snapshot LSN query")
 			}
-			defer conn.Close(ctx)
+			defer func() { _ = conn.Close(ctx) }()
 
 			query := fmt.Sprintf(`
 				SELECT snapshot_lsn, completed 
@@ -594,7 +601,7 @@ func (s *stream) fetchSnapshotLSN(ctx context.Context) (pq.LSN, error) {
 			resultReader := conn.Exec(ctx, query)
 			results, err := resultReader.ReadAll()
 			if err != nil {
-				resultReader.Close()
+				_ = resultReader.Close()
 				return errors.Wrap(err, "execute snapshot LSN query")
 			}
 
@@ -642,6 +649,7 @@ func (s *stream) fetchSnapshotLSN(ctx context.Context) (pq.LSN, error) {
 	return snapshotLSN, nil
 }
 
+// SendStandbyStatusUpdate sends a standby status update to the primary server.
 func SendStandbyStatusUpdate(_ context.Context, conn pq.Connection, walReceivedPosition, walFlushedPosition uint64) error {
 	data := make([]byte, 0, 34)
 	data = append(data, StandbyStatusUpdateByteID)
@@ -660,6 +668,7 @@ func SendStandbyStatusUpdate(_ context.Context, conn pq.Connection, walReceivedP
 	return conn.Frontend().SendUnbufferedEncodedCopyData(buf)
 }
 
+// AppendUint64 appends a big-endian encoded uint64 to the byte slice.
 func AppendUint64(buf []byte, n uint64) []byte {
 	wp := len(buf)
 	buf = append(buf, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -668,7 +677,7 @@ func AppendUint64(buf []byte, n uint64) []byte {
 }
 
 func timeToPgTime(t time.Time) uint64 {
-	return uint64(t.Unix()*1000000 + int64(t.Nanosecond())/1000 - microSecFromUnixEpochToY2K)
+	return uint64(t.Unix()*1000000 + int64(t.Nanosecond())/1000 - microSecFromUnixEpochToY2K) //nolint:gosec // G115: PG timestamp conversion is safe
 }
 
 func isClosed[T any](ch <-chan T) bool {

--- a/pq/replication/wal.go
+++ b/pq/replication/wal.go
@@ -13,6 +13,7 @@ import (
 // microSecFromUnixEpochToY2K is unix timestamp of 2000-01-01.
 var microSecFromUnixEpochToY2K = int64(946684800)
 
+// XLogData represents a parsed WAL data message from the replication stream.
 type XLogData struct {
 	ServerTime   time.Time
 	WALData      []byte
@@ -20,6 +21,7 @@ type XLogData struct {
 	ServerWALEnd pq.LSN
 }
 
+// ParseXLogData decodes a raw WAL data payload into an XLogData struct.
 func ParseXLogData(buf []byte) (XLogData, error) {
 	var xld XLogData
 	if len(buf) < 24 {
@@ -28,7 +30,7 @@ func ParseXLogData(buf []byte) (XLogData, error) {
 
 	xld.WALStart = pq.LSN(binary.BigEndian.Uint64(buf))
 	xld.ServerWALEnd = pq.LSN(binary.BigEndian.Uint64(buf[8:]))
-	xld.ServerTime = pgTimeToTime(int64(binary.BigEndian.Uint64(buf[16:])))
+	xld.ServerTime = pgTimeToTime(int64(binary.BigEndian.Uint64(buf[16:]))) //nolint:gosec // G115: PG timestamp fits int64
 	xld.WALData = buf[24:]
 
 	return xld, nil

--- a/pq/slot/config.go
+++ b/pq/slot/config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// Config holds the configuration for a replication slot.
 type Config struct {
 	Name                        string        `json:"name" yaml:"name"`
 	SlotActivityCheckerInterval time.Duration `json:"slotActivityCheckerInterval" yaml:"slotActivityCheckerInterval"`
@@ -16,6 +17,7 @@ type Config struct {
 	CreateIfNotExists bool `json:"createIfNotExists" yaml:"createIfNotExists"`
 }
 
+// Validate checks that all required slot configuration fields are set.
 func (c Config) Validate() error {
 	var err error
 	if strings.TrimSpace(c.Name) == "" {

--- a/pq/slot/info.go
+++ b/pq/slot/info.go
@@ -1,16 +1,20 @@
+// Package slot manages PostgreSQL replication slots for CDC.
 package slot
 
 import (
 	"github.com/Trendyol/go-pq-cdc/pq"
 )
 
+// Replication slot type constants.
 const (
 	Logical  Type = "logical"
 	Physical Type = "physical"
 )
 
+// Type represents a replication slot type (logical or physical).
 type Type string
 
+// Info holds status and position information for a replication slot.
 type Info struct {
 	Name              string `json:"name"`
 	Type              Type   `json:"type"`

--- a/pq/slot/slot.go
+++ b/pq/slot/slot.go
@@ -17,17 +17,22 @@ import (
 )
 
 var (
+	// ErrorSlotIsNotExists is returned when the replication slot does not exist.
 	ErrorSlotIsNotExists = goerrors.New("slot is not exists")
-	ErrorNotConnected    = goerrors.New("slot is not connected")
-	ErrorSlotClosed      = goerrors.New("slot is closed")
+	// ErrorNotConnected is returned when the slot connection is not established.
+	ErrorNotConnected = goerrors.New("slot is not connected")
+	// ErrorSlotClosed is returned when operating on a closed slot.
+	ErrorSlotClosed = goerrors.New("slot is closed")
 )
 
 var typeMap = pgtype.NewMap()
 
+// XLogUpdater is implemented by types that track WAL position updates.
 type XLogUpdater interface {
 	UpdateXLogPos(l pq.LSN)
 }
 
+// Slot manages a PostgreSQL logical replication slot.
 type Slot struct {
 	conn            pq.Connection
 	replicationConn pq.Connection
@@ -40,6 +45,7 @@ type Slot struct {
 	closed          atomic.Bool
 }
 
+// NewSlot creates a new replication slot manager with the given configuration.
 func NewSlot(replicationDSN, standardDSN string, cfg Config, m metric.Metric, updater XLogUpdater) *Slot {
 	query := fmt.Sprintf("SELECT slot_name, slot_type, active, active_pid, restart_lsn, confirmed_flush_lsn, wal_status, PG_CURRENT_WAL_LSN() AS current_lsn FROM pg_replication_slots WHERE slot_name = '%s';", cfg.Name)
 
@@ -54,12 +60,14 @@ func NewSlot(replicationDSN, standardDSN string, cfg Config, m metric.Metric, up
 	}
 }
 
+// Connect opens the standard database connection for slot operations.
 func (s *Slot) Connect(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.conn.Connect(ctx)
 }
 
+// Create creates the replication slot if it does not already exist.
 func (s *Slot) Create(ctx context.Context) (*Info, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -113,6 +121,7 @@ func (s *Slot) createSlotWithReplicationConn(ctx context.Context) error {
 	return nil
 }
 
+// Info returns the current status of the replication slot.
 func (s *Slot) Info(ctx context.Context) (*Info, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -147,6 +156,7 @@ func (s *Slot) infoLocked(ctx context.Context) (*Info, error) {
 	return slotInfo, nil
 }
 
+// Metrics periodically collects and reports replication slot metrics.
 func (s *Slot) Metrics(ctx context.Context) {
 	for range s.ticker.C {
 		if s.closed.Load() {
@@ -172,6 +182,7 @@ func (s *Slot) Metrics(ctx context.Context) {
 	}
 }
 
+// Close stops metrics collection and closes the slot connection.
 func (s *Slot) Close(ctx context.Context) {
 	s.closed.Store(true)
 	s.ticker.Stop()

--- a/pq/snapshot/connection_pool.go
+++ b/pq/snapshot/connection_pool.go
@@ -1,3 +1,4 @@
+// Package snapshot provides point-in-time snapshot capabilities for CDC initial data loads.
 package snapshot
 
 import (

--- a/pq/snapshot/job.go
+++ b/pq/snapshot/job.go
@@ -12,6 +12,7 @@ import (
 // ChunkStatus represents the status of a chunk
 type ChunkStatus string
 
+// Chunk status constants for tracking snapshot chunk progress.
 const (
 	ChunkStatusPending    ChunkStatus = "pending"
 	ChunkStatusInProgress ChunkStatus = "in_progress"
@@ -21,6 +22,7 @@ const (
 // PartitionStrategy defines how a table is partitioned for snapshot
 type PartitionStrategy string
 
+// Partition strategy constants for snapshot table chunking.
 const (
 	PartitionStrategyIntegerRange PartitionStrategy = "integer_range" // Single integer PK - MIN/MAX range
 	PartitionStrategyCTIDBlock    PartitionStrategy = "ctid_block"    // Physical block-based partitioning

--- a/pq/snapshot/snapshot.go
+++ b/pq/snapshot/snapshot.go
@@ -27,6 +27,7 @@ var (
 // Handler SnapshotHandler is a function that handles snapshot events
 type Handler func(event *format.Snapshot) error
 
+// Snapshotter manages the snapshot process for initial CDC data loads.
 type Snapshotter struct {
 	healthcheckConn    pq.Connection
 	exportSnapshotConn pq.Connection
@@ -52,6 +53,7 @@ type orderByCacheEntry struct {
 	columns []string
 }
 
+// New creates a new Snapshotter with the given configuration and database connections.
 func New(ctx context.Context, snapshotConfig config.SnapshotConfig, tables publication.Tables, dsn string, m metric.Metric) (*Snapshotter, error) {
 	metadataConn, err := pq.NewConnection(ctx, dsn)
 	if err != nil {

--- a/pq/snapshot/worker.go
+++ b/pq/snapshot/worker.go
@@ -536,12 +536,12 @@ func (s *Snapshotter) parseClaimedChunk(row [][]byte, slotName, instanceID strin
 	chunk.BlockEnd = blockEnd
 
 	// Parse is_last_chunk (boolean)
-	if row[10] != nil && len(row[10]) > 0 {
+	if len(row[10]) > 0 {
 		chunk.IsLastChunk = string(row[10]) == "t" || string(row[10]) == "true"
 	}
 
 	// Parse partition strategy
-	if row[11] != nil && len(row[11]) > 0 {
+	if len(row[11]) > 0 {
 		chunk.PartitionStrategy = PartitionStrategy(string(row[11]))
 	} else {
 		chunk.PartitionStrategy = PartitionStrategyOffset

--- a/pq/system.go
+++ b/pq/system.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
+// IdentifySystemResult holds the response from the IDENTIFY_SYSTEM replication command.
 type IdentifySystemResult struct {
 	mu       *sync.RWMutex
 	SystemID string
@@ -18,6 +19,7 @@ type IdentifySystemResult struct {
 	Timeline int32
 }
 
+// IdentifySystem executes the IDENTIFY_SYSTEM replication command and returns the result.
 func IdentifySystem(ctx context.Context, conn Connection) (IdentifySystemResult, error) {
 	res, err := ParseIdentifySystem(conn.Exec(ctx, "IDENTIFY_SYSTEM"))
 	if err != nil {
@@ -26,6 +28,7 @@ func IdentifySystem(ctx context.Context, conn Connection) (IdentifySystemResult,
 	return res, nil
 }
 
+// ParseIdentifySystem parses the result of the IDENTIFY_SYSTEM command.
 func ParseIdentifySystem(mrr *pgconn.MultiResultReader) (IdentifySystemResult, error) {
 	var isr IdentifySystemResult
 	results, err := mrr.ReadAll()
@@ -65,6 +68,7 @@ func ParseIdentifySystem(mrr *pgconn.MultiResultReader) (IdentifySystemResult, e
 	return isr, nil
 }
 
+// LoadXLogPos returns the current WAL position.
 func (isr *IdentifySystemResult) LoadXLogPos() LSN {
 	return isr.xLogPos
 }

--- a/pq/timescaledb/hypertable.go
+++ b/pq/timescaledb/hypertable.go
@@ -1,3 +1,4 @@
+// Package timescaledb provides hypertable discovery for TimescaleDB-backed CDC.
 package timescaledb
 
 import (
@@ -16,13 +17,16 @@ import (
 
 var typeMap = pgtype.NewMap()
 
+// HyperTables maps chunk names to their parent hypertable names.
 var HyperTables = sync.Map{}
 
+// TimescaleDB manages hypertable discovery and chunk-to-table mapping.
 type TimescaleDB struct {
 	conn   pq.Connection
 	ticker *time.Ticker
 }
 
+// NewTimescaleDB creates a new TimescaleDB instance with a database connection.
 func NewTimescaleDB(ctx context.Context, dsn string) (*TimescaleDB, error) {
 	conn, err := pq.NewConnection(ctx, dsn)
 	if err != nil {
@@ -32,6 +36,7 @@ func NewTimescaleDB(ctx context.Context, dsn string) (*TimescaleDB, error) {
 	return &TimescaleDB{conn: conn, ticker: time.NewTicker(time.Second)}, nil
 }
 
+// SyncHyperTables periodically refreshes the hypertable chunk mapping.
 func (tdb *TimescaleDB) SyncHyperTables(ctx context.Context) {
 	for range tdb.ticker.C {
 		hyperTables, err := tdb.FindHyperTables(ctx)
@@ -44,6 +49,7 @@ func (tdb *TimescaleDB) SyncHyperTables(ctx context.Context) {
 	}
 }
 
+// FindHyperTables queries TimescaleDB for all chunk-to-hypertable mappings.
 func (tdb *TimescaleDB) FindHyperTables(ctx context.Context) (map[string]string, error) {
 	query := "SELECT h.hypertable_schema, h.hypertable_name, c.chunk_schema, c.chunk_name FROM timescaledb_information.chunks c JOIN timescaledb_information.hypertables h ON c.hypertable_schema = h.hypertable_schema AND c.hypertable_name = h.hypertable_name;"
 	resultReader := tdb.conn.Exec(ctx, query)


### PR DESCRIPTION
## Summary                                                      
                                                                                                                                                                                                          
  - Upgrade minimum Go version from 1.22.4 to 1.24 across all modules, CI workflows, Dockerfiles, and Makefile                                                                                            
  - Update golangci-lint config (`.golangci.yml`) for v2 compatibility
  - Remove stray no-op `conn.Exec(ctx)` call in `pq/heartbeat/heartbeat.go`                                                                                                                               
                                                                                                                                                                                                          
  ## Motivation                                                                                                                                                                                           
                                                                                                                                                                                                          
  Go 1.22 is approaching end-of-life. Go 1.24 brings:                                                                                     
  - Swiss-table map implementation (faster map operations)
  - Range-over-func iterators and `iter` package                                                                                                                                                          
  - Generic type aliases                                                                                                                                                                                  
  - Cumulative runtime/GC improvements and security fixes                                                                                                                                                 
                                                                                                                                                                                                          
  We chose 1.24 over 1.26 to maintain broader consumer compatibility — anyone on Go 1.24+ can import this module.   