### PR TITLE
fix: check table existence before creating heartbeat table

### DIFF
--- a/pq/heartbeat/heartbeat.go
+++ b/pq/heartbeat/heartbeat.go
@@ -35,49 +35,62 @@ func New(dsn string, cfg config.HeartbeatConfig) *Heartbeat {
 	}
 }
 
-// EnsureTable creates the heartbeat table if it doesn't exist
+// EnsureTable checks if the heartbeat table exists and creates it only when missing.
+// This avoids permission errors for users who only have replication privileges.
 func (h *Heartbeat) EnsureTable(ctx context.Context, conn pq.Connection) error {
+	schema := quoteIdentifier(h.cfg.Table.Schema)
+	table := quoteIdentifier(h.cfg.Table.Name)
+
+	exists, err := pq.TableExists(ctx, conn, h.cfg.Table.Schema, h.cfg.Table.Name)
+	if err != nil {
+		return fmt.Errorf("check heartbeat table existence: %w", err)
+	}
+
+	if exists {
+		logger.Info("heartbeat table already exists, skipping creation", "table", schema+"."+table)
+		return nil
+	}
+
+	if err := h.createTable(ctx, conn); err != nil {
+		return err
+	}
+
+	if err := h.insertInitialRow(ctx, conn); err != nil {
+		return err
+	}
+
+	logger.Info("heartbeat table created", "table", schema+"."+table)
+	return nil
+}
+
+func (h *Heartbeat) createTable(ctx context.Context, conn pq.Connection) error {
 	schema := quoteIdentifier(h.cfg.Table.Schema)
 	table := quoteIdentifier(h.cfg.Table.Name)
 	constraint := quoteIdentifier(h.cfg.Table.Name + "_single_row")
 
-	createTableSQL := fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s.%s (
+	sql := fmt.Sprintf(`
+		CREATE TABLE %s.%s (
 			id INTEGER PRIMARY KEY DEFAULT 1,
 			last_heartbeat TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			CONSTRAINT %s CHECK (id = 1)
 		)`, schema, table, constraint)
 
-	insertRowSQL := fmt.Sprintf(`
-		INSERT INTO %s.%s (id) VALUES (1) ON CONFLICT DO NOTHING`, schema, table)
-
-	// Execute CREATE TABLE
-	resultReader := conn.Exec(ctx, createTableSQL)
-	if resultReader == nil {
-		return fmt.Errorf("create heartbeat table: exec returned nil")
-	}
-	if _, err := resultReader.ReadAll(); err != nil {
-		_ = resultReader.Close()
+	if err := pq.ExecSQL(ctx, conn, sql); err != nil {
 		return fmt.Errorf("create heartbeat table failed: %w", err)
 	}
-	if err := resultReader.Close(); err != nil {
-		return fmt.Errorf("close create table result: %w", err)
-	}
+	return nil
+}
 
-	// Execute INSERT initial row
-	resultReader = conn.Exec(ctx, insertRowSQL)
-	if resultReader == nil {
-		return fmt.Errorf("insert heartbeat row: exec returned nil")
-	}
-	if _, err := resultReader.ReadAll(); err != nil {
-		_ = resultReader.Close()
+func (h *Heartbeat) insertInitialRow(ctx context.Context, conn pq.Connection) error {
+	schema := quoteIdentifier(h.cfg.Table.Schema)
+	table := quoteIdentifier(h.cfg.Table.Name)
+
+	sql := fmt.Sprintf(`
+		INSERT INTO %s.%s (id) VALUES (1) ON CONFLICT DO NOTHING`, schema, table)
+
+	if err := pq.ExecSQL(ctx, conn, sql); err != nil {
 		return fmt.Errorf("insert heartbeat row failed: %w", err)
 	}
-	if err := resultReader.Close(); err != nil {
-		return fmt.Errorf("close insert result: %w", err)
-	}
-
-	logger.Info("heartbeat table created", "table", schema+"."+table)
 	return nil
 }
 

--- a/pq/query.go
+++ b/pq/query.go
@@ -1,0 +1,60 @@
+package pq
+
+import (
+	"context"
+	"fmt"
+)
+
+// ExecSQL executes a SQL statement without returning results.
+func ExecSQL(ctx context.Context, conn Connection, sql string) error {
+	resultReader := conn.Exec(ctx, sql)
+	_, err := resultReader.ReadAll()
+	if err != nil {
+		return err
+	}
+	return resultReader.Close()
+}
+
+// ExecExistsQuery executes a SELECT EXISTS query and returns the boolean result.
+func ExecExistsQuery(ctx context.Context, conn Connection, query string) (bool, error) {
+	resultReader := conn.Exec(ctx, query)
+	results, err := resultReader.ReadAll()
+	if err != nil {
+		return false, err
+	}
+	if err := resultReader.Close(); err != nil {
+		return false, err
+	}
+
+	if len(results) == 0 || len(results[0].Rows) == 0 || len(results[0].Rows[0]) == 0 {
+		return false, fmt.Errorf("no result returned from existence check")
+	}
+
+	return string(results[0].Rows[0][0]) == "t", nil
+}
+
+// TableExists checks if a table exists in the given schema using information_schema.
+func TableExists(ctx context.Context, conn Connection, schema, table string) (bool, error) {
+	query := fmt.Sprintf(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = '%s'
+			AND table_name = '%s'
+		)`, schema, table)
+
+	return ExecExistsQuery(ctx, conn, query)
+}
+
+// IndexExists checks if an index exists in the given schema using pg_indexes.
+func IndexExists(ctx context.Context, conn Connection, schema, index string) (bool, error) {
+	query := fmt.Sprintf(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_indexes
+			WHERE schemaname = '%s'
+			AND indexname = '%s'
+		)`, schema, index)
+
+	return ExecExistsQuery(ctx, conn, query)
+}

--- a/pq/snapshot/coordinator.go
+++ b/pq/snapshot/coordinator.go
@@ -249,7 +249,7 @@ func (s *Snapshotter) setupJob(ctx context.Context, slotName, instanceID string)
 
 func (s *Snapshotter) initTables(ctx context.Context) error {
 	// Check if job table exists
-	jobTableExists, err := s.tableExists(ctx, jobTableName)
+	jobTableExists, err := pq.TableExists(ctx, s.metadataConn, "public", jobTableName)
 	if err != nil {
 		return errors.Wrap(err, "check job table existence")
 	}
@@ -276,7 +276,7 @@ func (s *Snapshotter) initTables(ctx context.Context) error {
 	}
 
 	// Check if chunks table exists
-	chunksTableExists, err := s.tableExists(ctx, chunksTableName)
+	chunksTableExists, err := pq.TableExists(ctx, s.metadataConn, "public", chunksTableName)
 	if err != nil {
 		return errors.Wrap(err, "check chunks table existence")
 	}
@@ -322,12 +322,12 @@ func (s *Snapshotter) initTables(ctx context.Context) error {
 	}
 
 	for indexName, indexSQL := range indexes {
-		indexExists, err := s.indexExists(ctx, indexName)
+		exists, err := pq.IndexExists(ctx, s.metadataConn, "public", indexName)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("check index %s existence", indexName))
 		}
 
-		if !indexExists {
+		if !exists {
 			if err := s.execSQL(ctx, s.metadataConn, indexSQL); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("create index %s", indexName))
 			}
@@ -1227,56 +1227,4 @@ func hashString(s string) int64 {
 		hash = -hash
 	}
 	return hash
-}
-
-// tableExists checks if a table exists using information_schema
-// This approach only requires SELECT permission on information_schema
-func (s *Snapshotter) tableExists(ctx context.Context, tableName string) (bool, error) {
-	query := fmt.Sprintf(`
-		SELECT EXISTS (
-			SELECT 1 
-			FROM information_schema.tables 
-			WHERE table_schema = 'public' 
-			AND table_name = '%s'
-		)
-	`, tableName)
-
-	results, err := s.execQuery(ctx, s.metadataConn, query)
-	if err != nil {
-		return false, errors.Wrap(err, "query table existence")
-	}
-
-	if len(results) == 0 || len(results[0].Rows) == 0 || len(results[0].Rows[0]) == 0 {
-		return false, errors.New("no result returned from table existence check")
-	}
-
-	// PostgreSQL returns 't' for true, 'f' for false
-	exists := string(results[0].Rows[0][0]) == "t"
-	return exists, nil
-}
-
-// indexExists checks if an index exists using pg_indexes
-// This approach only requires SELECT permission on pg_indexes
-func (s *Snapshotter) indexExists(ctx context.Context, indexName string) (bool, error) {
-	query := fmt.Sprintf(`
-		SELECT EXISTS (
-			SELECT 1 
-			FROM pg_indexes 
-			WHERE schemaname = 'public' 
-			AND indexname = '%s'
-		)
-	`, indexName)
-
-	results, err := s.execQuery(ctx, s.metadataConn, query)
-	if err != nil {
-		return false, errors.Wrap(err, "query index existence")
-	}
-
-	if len(results) == 0 || len(results[0].Rows) == 0 || len(results[0].Rows[0]) == 0 {
-		return false, errors.New("no result returned from index existence check")
-	}
-
-	// PostgreSQL returns 't' for true, 'f' for false
-	exists := string(results[0].Rows[0][0]) == "t"
-	return exists, nil
 }

--- a/pq/snapshot/helpers.go
+++ b/pq/snapshot/helpers.go
@@ -23,12 +23,7 @@ const (
 
 // execSQL executes a SQL statement without returning results (DDL, DML)
 func (s *Snapshotter) execSQL(ctx context.Context, conn pq.Connection, sql string) error {
-	resultReader := conn.Exec(ctx, sql)
-	_, err := resultReader.ReadAll()
-	if err != nil {
-		return err
-	}
-	return resultReader.Close()
+	return pq.ExecSQL(ctx, conn, sql)
 }
 
 // execQuery executes a SQL query and returns results


### PR DESCRIPTION
Created new query.go file to store sql query execution methods.

Refactor: Centralize table and index existence checks in the `pq` package.

Refactored `Heartbeat` and `Snapshot` modules to use new `ExecSQL` and utility methods (`TableExists`, `IndexExists`) from the `pq` package for cleaner code and improved reusability. Removed redundant methods from `Snapshotter`.