### PR TITLE
Make stream close idempotent

### DIFF
--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -67,6 +67,7 @@ type stream struct {
 	snapshotLSN         pq.LSN
 	openFromSnapshotLSN bool
 	closed              atomic.Bool
+	sinkStarted         atomic.Bool
 }
 
 func NewStream(dsn string, cfg config.Config, m metric.Metric, listenerFunc ListenerFunc) Streamer {
@@ -108,8 +109,6 @@ func (s *stream) Open(ctx context.Context) error {
 	}
 
 	if err := s.setup(ctx); err != nil {
-		s.sinkEnd <- struct{}{}
-
 		var v *pgconn.PgError
 		if goerrors.As(err, &v) && v.Code == "55006" {
 			return ErrorSlotInUse
@@ -117,6 +116,7 @@ func (s *stream) Open(ctx context.Context) error {
 		return errors.Wrap(err, "replication setup")
 	}
 
+	s.sinkStarted.Store(true)
 	go s.sink(ctx)
 
 	go s.process(ctx)
@@ -508,13 +508,14 @@ func (s *stream) isHeartbeatMessage(msg any) bool {
 }
 
 func (s *stream) Close(ctx context.Context) {
-	s.closed.Store(true)
-
-	<-s.sinkEnd
-	if !isClosed(s.sinkEnd) {
-		close(s.sinkEnd)
+	if !s.closed.CompareAndSwap(false, true) {
+		return
 	}
-	logger.Info("postgres message sink stopped")
+
+	if s.sinkStarted.Load() {
+		<-s.sinkEnd
+		logger.Info("postgres message sink stopped")
+	}
 
 	if !s.conn.IsClosed() {
 		_ = s.conn.Close(ctx)
@@ -669,14 +670,4 @@ func AppendUint64(buf []byte, n uint64) []byte {
 
 func timeToPgTime(t time.Time) uint64 {
 	return uint64(t.Unix()*1000000 + int64(t.Nanosecond())/1000 - microSecFromUnixEpochToY2K)
-}
-
-func isClosed[T any](ch <-chan T) bool {
-	select {
-	case <-ch:
-		return true
-	default:
-	}
-
-	return false
 }

--- a/pq/replication/stream_test.go
+++ b/pq/replication/stream_test.go
@@ -1,0 +1,48 @@
+package replication
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/internal/metric"
+)
+
+func TestStreamCloseBeforeOpenDoesNotBlock(t *testing.T) {
+	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(*ListenerContext) {})
+
+	requireCloseReturns(t, stream, "Close blocked before Open started the sink")
+}
+
+func TestStreamCloseIsIdempotentBeforeOpen(t *testing.T) {
+	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(*ListenerContext) {})
+	requireCloseReturns(t, stream, "first Close blocked")
+	requireCloseReturns(t, stream, "second Close blocked")
+}
+
+func TestStreamCloseAfterOpenFailureDoesNotBlock(t *testing.T) {
+	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(*ListenerContext) {})
+
+	if err := stream.Open(context.Background()); err == nil {
+		t.Fatal("expected Open to fail without a connected postgres connection")
+	}
+
+	requireCloseReturns(t, stream, "Close blocked after Open failed before starting the sink")
+}
+
+func requireCloseReturns(t *testing.T, stream Streamer, msg string) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		stream.Close(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal(msg)
+	}
+}


### PR DESCRIPTION
## Overview

`Stream.Close` could block forever when callers closed a stream before the sink goroutine had started. That makes common cleanup patterns such as `defer connector.Close()` unsafe if startup fails before replication streaming begins.

This PR makes stream shutdown idempotent and ensures `Close` only waits for the sink when the sink was actually started.

## Technical explanation

The previous implementation always waited on `sinkEnd`:

```go
<-s.sinkEnd
```

That channel is signaled by the sink goroutine. If `Open` was never called, or if `Open` returned before starting the sink, no goroutine exists to send that signal, so `Close` blocks indefinitely.

The fix adds explicit sink lifecycle state:

- record when `Open` has successfully reached the point where it starts the sink goroutine
- use `closed.CompareAndSwap(false, true)` so repeated `Close` calls return immediately
- wait on `sinkEnd` only when a sink was started
- remove the synthetic `sinkEnd` send from the setup-error path

This keeps the existing behavior for running streams while making pre-start and failed-start cleanup safe.

## Tests

Added regression tests in `pq/replication/stream_test.go` for:

- closing before `Open`
- closing more than once before `Open`
- closing after `Open` fails before starting the sink

The new tests fail without the code fix:

```text
mise x go@1.23.2 -- go test ./pq/replication -run TestStreamClose -count=1 -timeout 2s
```

Validation with the fix:

```text
mise x go@1.23.2 -- go test ./pq/replication
mise x go@1.23.2 -- go test ./...
```
