### PR TITLE
Fix logical replication timestamp conversion

### DIFF
--- a/pq/message/format/begin.go
+++ b/pq/message/format/begin.go
@@ -30,7 +30,7 @@ func (b *Begin) decode(data []byte) error {
 
 	b.FinalLSN = pq.LSN(binary.BigEndian.Uint64(data[skipByte:]))
 	skipByte += 8
-	b.CommitTime = time.Unix(int64(binary.BigEndian.Uint64(data[skipByte:])), 0)
+	b.CommitTime = pgTimeToTime(int64(binary.BigEndian.Uint64(data[skipByte:])))
 	skipByte += 8
 	b.Xid = binary.BigEndian.Uint32(data[skipByte:])
 

--- a/pq/message/format/begin_test.go
+++ b/pq/message/format/begin_test.go
@@ -2,7 +2,6 @@ package format
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -16,7 +15,7 @@ func TestNewBegin(t *testing.T) {
 		data := []byte{
 			66,                          // Message type 'B'
 			0, 0, 0, 0, 1, 150, 157, 24, // FinalLSN: 0x1969D18 = 26647832
-			0, 2, 234, 4, 120, 77, 196, 132, // CommitTime: 0x2EA04784DC484 = 820254872552580 microseconds from 2000-01-01 (as Unix seconds in decode)
+			0, 2, 234, 4, 120, 77, 196, 132, // CommitTime: 0x2EA04784DC484 = 820254872552580 microseconds from 2000-01-01
 			0, 0, 2, 249, // Xid: 0x2F9 = 761
 		}
 
@@ -27,8 +26,8 @@ func TestNewBegin(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, begin)
 		assert.Equal(t, pq.LSN(26647832), begin.FinalLSN)
-		// The decode function treats the 8 bytes as Unix seconds directly
-		assert.Equal(t, time.Unix(820254872552580, 0), begin.CommitTime)
+		// The decode function treats the 8 bytes as PostgreSQL time.
+		assert.Equal(t, pgTimeForTest(820254872552580), begin.CommitTime)
 		assert.Equal(t, uint32(761), begin.Xid)
 	})
 
@@ -54,7 +53,7 @@ func TestNewBegin(t *testing.T) {
 		data := []byte{
 			66,                     // Message type 'B'
 			0, 0, 0, 0, 0, 0, 0, 1, // FinalLSN: 1
-			0, 0, 0, 0, 0, 0, 0, 0, // CommitTime: 0 (Unix epoch)
+			0, 0, 0, 0, 0, 0, 0, 0, // CommitTime: 0
 			0, 0, 0, 1, // Xid: 1
 		}
 
@@ -65,7 +64,7 @@ func TestNewBegin(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, begin)
 		assert.Equal(t, pq.LSN(1), begin.FinalLSN)
-		assert.Equal(t, time.Unix(0, 0), begin.CommitTime)
+		assert.Equal(t, pgTimeForTest(0), begin.CommitTime)
 		assert.Equal(t, uint32(1), begin.Xid)
 	})
 
@@ -95,7 +94,7 @@ func TestBegin_decode(t *testing.T) {
 		data := []byte{
 			66,                          // Message type 'B'
 			0, 0, 0, 0, 1, 150, 157, 24, // FinalLSN: 26647832
-			0, 2, 234, 4, 120, 77, 196, 132, // CommitTime: 820254872552580 as Unix seconds
+			0, 2, 234, 4, 120, 77, 196, 132, // CommitTime: 820254872552580
 			0, 0, 2, 249, // Xid: 761
 		}
 		begin := &Begin{}
@@ -106,7 +105,7 @@ func TestBegin_decode(t *testing.T) {
 		// Then
 		require.NoError(t, err)
 		assert.Equal(t, pq.LSN(26647832), begin.FinalLSN)
-		assert.Equal(t, time.Unix(820254872552580, 0), begin.CommitTime)
+		assert.Equal(t, pgTimeForTest(820254872552580), begin.CommitTime)
 		assert.Equal(t, uint32(761), begin.Xid)
 	})
 
@@ -148,7 +147,7 @@ func TestBegin_decode(t *testing.T) {
 		// Then
 		require.NoError(t, err)
 		assert.Equal(t, pq.LSN(0), begin.FinalLSN)
-		assert.Equal(t, time.Unix(0, 0), begin.CommitTime)
+		assert.Equal(t, pgTimeForTest(0), begin.CommitTime)
 		assert.Equal(t, uint32(0), begin.Xid)
 	})
 }

--- a/pq/message/format/commit.go
+++ b/pq/message/format/commit.go
@@ -35,7 +35,7 @@ func (c *Commit) decode(data []byte) error {
 	skipByte += 8
 	c.TransactionEndLSN = pq.LSN(binary.BigEndian.Uint64(data[skipByte:]))
 	skipByte += 8
-	c.CommitTime = time.Unix(int64(binary.BigEndian.Uint64(data[skipByte:])), 0)
+	c.CommitTime = pgTimeToTime(int64(binary.BigEndian.Uint64(data[skipByte:])))
 
 	return nil
 }

--- a/pq/message/format/commit_test.go
+++ b/pq/message/format/commit_test.go
@@ -2,7 +2,6 @@ package format
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -18,7 +17,7 @@ func TestNewCommit(t *testing.T) {
 			0,                           // Flags
 			0, 0, 0, 0, 1, 150, 157, 24, // CommitLSN: 0x1969D18 = 26647832
 			0, 0, 0, 0, 1, 150, 157, 72, // TransactionEndLSN: 0x1969D48 = 26647880
-			0, 2, 234, 4, 120, 77, 196, 132, // CommitTime: 0x2EA04784DC484 = 820254872552580 as Unix seconds
+			0, 2, 234, 4, 120, 77, 196, 132, // CommitTime: 0x2EA04784DC484 = 820254872552580
 		}
 
 		// When
@@ -30,7 +29,7 @@ func TestNewCommit(t *testing.T) {
 		assert.Equal(t, uint8(0), commit.Flags)
 		assert.Equal(t, pq.LSN(26647832), commit.CommitLSN)
 		assert.Equal(t, pq.LSN(26647880), commit.TransactionEndLSN)
-		assert.Equal(t, time.Unix(820254872552580, 0), commit.CommitTime)
+		assert.Equal(t, pgTimeForTest(820254872552580), commit.CommitTime)
 	})
 
 	t.Run("should return error when data is too short", func(t *testing.T) {
@@ -58,7 +57,7 @@ func TestNewCommit(t *testing.T) {
 			0,                      // Flags
 			0, 0, 0, 0, 0, 0, 0, 1, // CommitLSN: 1
 			0, 0, 0, 0, 0, 0, 0, 2, // TransactionEndLSN: 2
-			0, 0, 0, 0, 0, 0, 0, 0, // CommitTime: 0 (Unix epoch)
+			0, 0, 0, 0, 0, 0, 0, 0, // CommitTime: 0
 		}
 
 		// When
@@ -70,7 +69,7 @@ func TestNewCommit(t *testing.T) {
 		assert.Equal(t, uint8(0), commit.Flags)
 		assert.Equal(t, pq.LSN(1), commit.CommitLSN)
 		assert.Equal(t, pq.LSN(2), commit.TransactionEndLSN)
-		assert.Equal(t, time.Unix(0, 0), commit.CommitTime)
+		assert.Equal(t, pgTimeForTest(0), commit.CommitTime)
 	})
 
 	t.Run("should decode commit message with flags set", func(t *testing.T) {
@@ -92,7 +91,7 @@ func TestNewCommit(t *testing.T) {
 		assert.Equal(t, uint8(1), commit.Flags)
 		assert.Equal(t, pq.LSN(100), commit.CommitLSN)
 		assert.Equal(t, pq.LSN(200), commit.TransactionEndLSN)
-		assert.Equal(t, time.Unix(123, 0), commit.CommitTime)
+		assert.Equal(t, pgTimeForTest(123), commit.CommitTime)
 	})
 
 	t.Run("should decode commit message with maximum values", func(t *testing.T) {
@@ -125,7 +124,7 @@ func TestCommit_decode(t *testing.T) {
 			0,                           // Flags
 			0, 0, 0, 0, 1, 150, 157, 24, // CommitLSN: 26647832
 			0, 0, 0, 0, 1, 150, 157, 72, // TransactionEndLSN: 26647880
-			0, 2, 234, 4, 120, 77, 196, 132, // CommitTime: 820254872552580 as Unix seconds
+			0, 2, 234, 4, 120, 77, 196, 132, // CommitTime: 820254872552580
 		}
 		commit := &Commit{}
 
@@ -137,7 +136,7 @@ func TestCommit_decode(t *testing.T) {
 		assert.Equal(t, uint8(0), commit.Flags)
 		assert.Equal(t, pq.LSN(26647832), commit.CommitLSN)
 		assert.Equal(t, pq.LSN(26647880), commit.TransactionEndLSN)
-		assert.Equal(t, time.Unix(820254872552580, 0), commit.CommitTime)
+		assert.Equal(t, pgTimeForTest(820254872552580), commit.CommitTime)
 	})
 
 	t.Run("should return error for empty data", func(t *testing.T) {
@@ -180,7 +179,7 @@ func TestCommit_decode(t *testing.T) {
 		assert.Equal(t, uint8(0), commit.Flags)
 		assert.Equal(t, pq.LSN(0), commit.CommitLSN)
 		assert.Equal(t, pq.LSN(0), commit.TransactionEndLSN)
-		assert.Equal(t, time.Unix(0, 0), commit.CommitTime)
+		assert.Equal(t, pgTimeForTest(0), commit.CommitTime)
 	})
 
 	t.Run("should decode with non-zero flags", func(t *testing.T) {
@@ -202,6 +201,6 @@ func TestCommit_decode(t *testing.T) {
 		assert.Equal(t, uint8(255), commit.Flags)
 		assert.Equal(t, pq.LSN(256), commit.CommitLSN)
 		assert.Equal(t, pq.LSN(512), commit.TransactionEndLSN)
-		assert.Equal(t, time.Unix(1677721600, 0), commit.CommitTime)
+		assert.Equal(t, pgTimeForTest(1677721600), commit.CommitTime)
 	})
 }

--- a/pq/message/format/keepalive.go
+++ b/pq/message/format/keepalive.go
@@ -37,9 +37,3 @@ func (p *PrimaryKeepaliveMessage) decode(data []byte) error {
 	p.ReplyRequested = data[16] != 0
 	return nil
 }
-
-// pgTimeToTime converts microseconds since 2000-01-01 (Y2K) to time.Time (UTC).
-func pgTimeToTime(microSecSinceY2K int64) time.Time {
-	const microSecFromUnixEpochToY2K = int64(946684800) // Unix timestamp of 2000-01-01
-	return time.Unix(microSecFromUnixEpochToY2K+(microSecSinceY2K/1_000_000), (microSecSinceY2K%1_000_000)*1_000).UTC()
-}

--- a/pq/message/format/stream.go
+++ b/pq/message/format/stream.go
@@ -101,7 +101,7 @@ func (sc *StreamCommit) decode(data []byte) error {
 	skipByte += 8
 	sc.TransactionEndLSN = pq.LSN(binary.BigEndian.Uint64(data[skipByte:]))
 	skipByte += 8
-	sc.CommitTime = time.Unix(int64(binary.BigEndian.Uint64(data[skipByte:])), 0)
+	sc.CommitTime = pgTimeToTime(int64(binary.BigEndian.Uint64(data[skipByte:])))
 
 	return nil
 }

--- a/pq/message/format/stream_test.go
+++ b/pq/message/format/stream_test.go
@@ -2,7 +2,6 @@ package format
 
 import (
 	"testing"
-	"time"
 
 	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/stretchr/testify/assert"
@@ -224,7 +223,7 @@ func TestNewStreamCommit(t *testing.T) {
 		assert.Equal(t, uint8(0), sc.Flags)
 		assert.Equal(t, pq.LSN(26647832), sc.CommitLSN)
 		assert.Equal(t, pq.LSN(26647880), sc.TransactionEndLSN)
-		assert.Equal(t, time.Unix(123, 0), sc.CommitTime)
+		assert.Equal(t, pgTimeForTest(123), sc.CommitTime)
 	})
 
 	t.Run("should return error when data is too short", func(t *testing.T) {
@@ -266,7 +265,7 @@ func TestNewStreamCommit(t *testing.T) {
 		assert.Equal(t, uint8(0), sc.Flags)
 		assert.Equal(t, pq.LSN(1), sc.CommitLSN)
 		assert.Equal(t, pq.LSN(2), sc.TransactionEndLSN)
-		assert.Equal(t, time.Unix(0, 0), sc.CommitTime)
+		assert.Equal(t, pgTimeForTest(0), sc.CommitTime)
 	})
 
 	t.Run("should return error for empty data", func(t *testing.T) {
@@ -302,6 +301,6 @@ func TestNewStreamCommit(t *testing.T) {
 		assert.Equal(t, uint8(1), sc.Flags)
 		assert.Equal(t, pq.LSN(100), sc.CommitLSN)
 		assert.Equal(t, pq.LSN(200), sc.TransactionEndLSN)
-		assert.Equal(t, time.Unix(50, 0), sc.CommitTime)
+		assert.Equal(t, pgTimeForTest(50), sc.CommitTime)
 	})
 }

--- a/pq/message/format/time.go
+++ b/pq/message/format/time.go
@@ -1,0 +1,10 @@
+package format
+
+import "time"
+
+const microSecFromUnixEpochToY2K = int64(946684800) * 1_000_000
+
+// pgTimeToTime converts microseconds since 2000-01-01 (Y2K) to time.Time (UTC).
+func pgTimeToTime(microSecSinceY2K int64) time.Time {
+	return time.UnixMicro(microSecFromUnixEpochToY2K + microSecSinceY2K).UTC()
+}

--- a/pq/message/format/time_test.go
+++ b/pq/message/format/time_test.go
@@ -1,0 +1,17 @@
+package format
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPgTimeToTime(t *testing.T) {
+	assert.Equal(t, time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), pgTimeToTime(0))
+	assert.Equal(t, time.Date(2000, 1, 1, 0, 0, 1, 123456000, time.UTC), pgTimeToTime(1_123_456))
+}
+
+func pgTimeForTest(microSecSinceY2K int64) time.Time {
+	return time.UnixMicro(int64(946684800)*1_000_000 + microSecSinceY2K).UTC()
+}

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -668,7 +668,7 @@ func AppendUint64(buf []byte, n uint64) []byte {
 }
 
 func timeToPgTime(t time.Time) uint64 {
-	return uint64(t.Unix()*1000000 + int64(t.Nanosecond())/1000 - microSecFromUnixEpochToY2K)
+	return uint64(t.UTC().UnixMicro() - microSecFromUnixEpochToY2K)
 }
 
 func isClosed[T any](ch <-chan T) bool {

--- a/pq/replication/wal.go
+++ b/pq/replication/wal.go
@@ -10,8 +10,7 @@ import (
 )
 
 // The server's system clock at the time of transmission, as microseconds since midnight on 2000-01-01.
-// microSecFromUnixEpochToY2K is unix timestamp of 2000-01-01.
-var microSecFromUnixEpochToY2K = int64(946684800)
+const microSecFromUnixEpochToY2K = int64(946684800) * 1_000_000
 
 type XLogData struct {
 	ServerTime   time.Time
@@ -35,5 +34,5 @@ func ParseXLogData(buf []byte) (XLogData, error) {
 }
 
 func pgTimeToTime(microSecSinceY2K int64) time.Time {
-	return time.Unix(microSecFromUnixEpochToY2K+(microSecSinceY2K/1_000_000), (microSecSinceY2K%1_000_000)*1_000).UTC()
+	return time.UnixMicro(microSecFromUnixEpochToY2K + microSecSinceY2K).UTC()
 }

--- a/pq/replication/wal_test.go
+++ b/pq/replication/wal_test.go
@@ -1,0 +1,17 @@
+package replication
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPgTimeConversions(t *testing.T) {
+	ts := time.Date(2026, 4, 24, 12, 30, 15, 123456000, time.UTC)
+	pgEpoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	pgTime := timeToPgTime(ts)
+
+	assert.Equal(t, uint64(ts.Sub(pgEpoch)/time.Microsecond), pgTime)
+	assert.Equal(t, ts, pgTimeToTime(int64(pgTime)))
+}


### PR DESCRIPTION
## Overview

Logical replication timestamps were decoded with the wrong epoch and unit in several places. PostgreSQL sends these values as microseconds since `2000-01-01`, but Begin, Commit, and StreamCommit messages treated them as Unix seconds.

This PR centralizes PostgreSQL timestamp conversion for logical message parsing and fixes the standby status timestamp sent back to PostgreSQL.

## Technical explanation

PostgreSQL logical replication uses microseconds since the PostgreSQL epoch (`2000-01-01 00:00:00 UTC`) for these timestamp fields. The code already used that conversion for keepalive and XLogData paths, but transaction messages decoded the raw `int64` with:

```go
time.Unix(raw, 0)
```

That produces dates far in the future for real PostgreSQL values and maps raw zero to the Unix epoch instead of the PostgreSQL epoch.

The change:

- moves the message-format PostgreSQL timestamp helper into a shared `time.go`
- uses that helper for Begin, Commit, StreamCommit, and keepalive parsing
- changes replication timestamp encoding to subtract the PostgreSQL epoch in microseconds, not seconds
- updates tests to assert PostgreSQL epoch semantics

## Tests

The updated tests fail without the code fix, including Begin/Commit/StreamCommit parser expectations and standby-status timestamp conversion:

```text
mise x go@1.23.2 -- go test ./pq/message/format ./pq/replication -run 'Test(NewBegin|Begin_decode|NewCommit|Commit_decode|NewStreamCommit|PgTimeConversions)' -count=1
```

Validation with the fix:

```text
mise x go@1.23.2 -- go test ./pq/message/format ./pq/replication
mise x go@1.23.2 -- go test ./...
```
