### PR TITLE
Decode truncate replication messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ func Handler(ctx *replication.ListenerContext) {
 		slog.Info("delete message received", "old", msg.OldDecoded)
 	case *format.Update:
 		slog.Info("update message received", "new", msg.NewDecoded, "old", msg.OldDecoded)
+	case *format.Truncate:
+		slog.Info("truncate message received", "relations", msg.RelationOIDs, "cascade", msg.Cascade, "restartIdentity", msg.RestartIdentity)
 	}
 
 	if err := ctx.Ack(); err != nil {

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -85,6 +85,8 @@ func Handler(ctx *replication.ListenerContext) {
 		slog.Info("delete message received", "old", msg.OldDecoded)
 	case *format.Update:
 		slog.Info("update message received", "new", msg.NewDecoded, "old", msg.OldDecoded)
+	case *format.Truncate:
+		slog.Info("truncate message received", "relations", msg.RelationOIDs, "cascade", msg.Cascade, "restartIdentity", msg.RestartIdentity)
 	}
 
 	if err := ctx.Ack(); err != nil {

--- a/pq/message/format/truncate.go
+++ b/pq/message/format/truncate.go
@@ -1,0 +1,79 @@
+package format
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/go-playground/errors"
+)
+
+const (
+	TruncateOptionCascade         = 1
+	TruncateOptionRestartIdentity = 2
+)
+
+type Truncate struct {
+	MessageTime     time.Time
+	Relations       []*Relation
+	RelationOIDs    []uint32
+	XID             uint32
+	Options         uint8
+	Cascade         bool
+	RestartIdentity bool
+}
+
+func NewTruncate(data []byte, streamedTransaction bool, relation map[uint32]*Relation, serverTime time.Time) (*Truncate, error) {
+	msg := &Truncate{
+		MessageTime: serverTime,
+	}
+	if err := msg.decode(data, streamedTransaction); err != nil {
+		return nil, err
+	}
+
+	msg.Relations = make([]*Relation, len(msg.RelationOIDs))
+	for i, oid := range msg.RelationOIDs {
+		rel, ok := relation[oid]
+		if !ok {
+			return nil, errors.New("relation not found")
+		}
+		msg.Relations[i] = rel
+	}
+
+	return msg, nil
+}
+
+func (m *Truncate) decode(data []byte, streamedTransaction bool) error {
+	skipByte := 1
+
+	if streamedTransaction {
+		if len(data) < 10 {
+			return errors.Newf("streamed transaction truncate message length must be at least 10 byte, but got %d", len(data))
+		}
+
+		m.XID = binary.BigEndian.Uint32(data[skipByte:])
+		skipByte += 4
+	}
+
+	if len(data) < skipByte+5 {
+		return errors.Newf("truncate message length must be at least %d byte, but got %d", skipByte+5, len(data))
+	}
+
+	relationCount := int(binary.BigEndian.Uint32(data[skipByte:]))
+	skipByte += 4
+	m.Options = data[skipByte]
+	skipByte++
+
+	if len(data) < skipByte+(relationCount*4) {
+		return errors.Newf("truncate message relation IDs length must be %d byte, but got %d", relationCount*4, len(data)-skipByte)
+	}
+
+	m.Cascade = m.Options&TruncateOptionCascade != 0
+	m.RestartIdentity = m.Options&TruncateOptionRestartIdentity != 0
+	m.RelationOIDs = make([]uint32, relationCount)
+	for i := range m.RelationOIDs {
+		m.RelationOIDs[i] = binary.BigEndian.Uint32(data[skipByte:])
+		skipByte += 4
+	}
+
+	return nil
+}

--- a/pq/message/format/truncate_test.go
+++ b/pq/message/format/truncate_test.go
@@ -1,0 +1,95 @@
+package format
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncate_New(t *testing.T) {
+	now := time.Now()
+	relations := map[uint32]*Relation{
+		42: {OID: 42, Namespace: "public", Name: "authors"},
+		43: {OID: 43, Namespace: "public", Name: "books"},
+	}
+
+	t.Run("decodes truncate message", func(t *testing.T) {
+		data := []byte{
+			'T',
+			0, 0, 0, 2, // relation count
+			3, // cascade + restart identity
+			0, 0, 0, 42,
+			0, 0, 0, 43,
+		}
+
+		msg, err := NewTruncate(data, false, relations, now)
+
+		require.NoError(t, err)
+		assert.Equal(t, now, msg.MessageTime)
+		assert.Equal(t, []uint32{42, 43}, msg.RelationOIDs)
+		assert.Equal(t, []*Relation{relations[42], relations[43]}, msg.Relations)
+		assert.Equal(t, uint8(3), msg.Options)
+		assert.True(t, msg.Cascade)
+		assert.True(t, msg.RestartIdentity)
+		assert.Zero(t, msg.XID)
+	})
+
+	t.Run("decodes streamed truncate message", func(t *testing.T) {
+		data := []byte{
+			'T',
+			0, 0, 0, 99, // xid
+			0, 0, 0, 1, // relation count
+			1, // cascade
+			0, 0, 0, 42,
+		}
+
+		msg, err := NewTruncate(data, true, relations, now)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint32(99), msg.XID)
+		assert.Equal(t, []uint32{42}, msg.RelationOIDs)
+		assert.Equal(t, []*Relation{relations[42]}, msg.Relations)
+		assert.True(t, msg.Cascade)
+		assert.False(t, msg.RestartIdentity)
+	})
+
+	t.Run("returns error when relation is missing", func(t *testing.T) {
+		data := []byte{
+			'T',
+			0, 0, 0, 1, // relation count
+			0, // options
+			0, 0, 0, 44,
+		}
+
+		msg, err := NewTruncate(data, false, relations, now)
+
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		assert.Contains(t, err.Error(), "relation not found")
+	})
+
+	t.Run("returns error when data is too short", func(t *testing.T) {
+		msg, err := NewTruncate([]byte{'T', 0, 0}, false, relations, now)
+
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		assert.Contains(t, err.Error(), "truncate message length")
+	})
+
+	t.Run("returns error when relation IDs are incomplete", func(t *testing.T) {
+		data := []byte{
+			'T',
+			0, 0, 0, 2, // relation count
+			0, // options
+			0, 0, 0, 42,
+		}
+
+		msg, err := NewTruncate(data, false, relations, now)
+
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		assert.Contains(t, err.Error(), "truncate message relation IDs length")
+	})
+}

--- a/pq/message/message.go
+++ b/pq/message/message.go
@@ -47,6 +47,8 @@ func New(data []byte, serverTime time.Time, relation map[uint32]*format.Relation
 		return format.NewUpdate(data, streamedTransaction, relation, serverTime)
 	case DeleteByte:
 		return format.NewDelete(data, streamedTransaction, relation, serverTime)
+	case TruncateByte:
+		return format.NewTruncate(data, streamedTransaction, relation, serverTime)
 	case StreamStartByte:
 		streamedTransaction = true
 		return format.NewStreamStart(data)

--- a/pq/message/message_test.go
+++ b/pq/message/message_test.go
@@ -1,0 +1,34 @@
+package message
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDecodesTruncate(t *testing.T) {
+	now := time.Now()
+	relations := map[uint32]*format.Relation{
+		42: {OID: 42, Namespace: "public", Name: "books"},
+	}
+	data := []byte{
+		'T',
+		0, 0, 0, 1, // relation count
+		2, // restart identity
+		0, 0, 0, 42,
+	}
+
+	msg, err := New(data, now, relations)
+
+	require.NoError(t, err)
+	truncate, ok := msg.(*format.Truncate)
+	require.True(t, ok)
+	assert.Equal(t, now, truncate.MessageTime)
+	assert.Equal(t, []uint32{42}, truncate.RelationOIDs)
+	assert.Equal(t, []*format.Relation{relations[42]}, truncate.Relations)
+	assert.False(t, truncate.Cascade)
+	assert.True(t, truncate.RestartIdentity)
+}


### PR DESCRIPTION
## Overview

The project allowed `TRUNCATE` in publication operations and defined the pgoutput truncate message byte, but the message dispatcher did not decode truncate events. As a result, configured truncate events were rejected as unsupported messages.

This PR adds pgoutput TRUNCATE decoding and wires it into `message.New`.

## Technical explanation

PostgreSQL pgoutput TRUNCATE messages contain:

- an optional XID when the message is part of a streamed transaction
- the number of truncated relations
- option bits for `CASCADE` and `RESTART IDENTITY`
- one relation OID per truncated relation

The new `format.Truncate` type decodes those fields, resolves relation OIDs through the existing relation cache, and exposes both the raw relation IDs and resolved relation metadata. `message.New` now dispatches `TruncateByte` to this decoder instead of falling through to `message byte not supported`.

## Tests

Added coverage for:

- direct truncate message decoding
- streamed truncate messages with XID
- cascade/restart-identity option bits
- missing relation metadata
- incomplete message payloads
- `message.New` dispatching `TruncateByte`

The dispatch test fails without the `message.New` fix:

```text
mise x go@1.23.2 -- go test ./pq/message -run TestNewDecodesTruncate -count=1
```

Validation with the fix:

```text
mise x go@1.23.2 -- go test ./pq/message ./pq/message/format
mise x go@1.23.2 -- go test ./...
```
