### PR TITLE
Advance received WAL position from XLogData

### DIFF
--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -383,6 +383,7 @@ func (s *stream) handleXLogData(data []byte, buf *messageBuffer, streamBuf *stre
 		"serverTime", xld.ServerTime,
 	)
 
+	s.UpdateXLogPos(xld.ServerWALEnd)
 	s.metric.SetCDCLatency(time.Now().UTC().Sub(xld.ServerTime).Nanoseconds())
 
 	decodedMsg, err := message.New(xld.WALData, xld.ServerTime, s.relation)

--- a/pq/replication/stream_ack_test.go
+++ b/pq/replication/stream_ack_test.go
@@ -1,0 +1,28 @@
+package replication
+
+import (
+	"encoding/binary"
+	"log/slog"
+	"testing"
+
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/internal/metric"
+	"github.com/Trendyol/go-pq-cdc/logger"
+	"github.com/Trendyol/go-pq-cdc/pq"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleXLogDataUpdatesReceivedPosition(t *testing.T) {
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(*ListenerContext) {}).(*stream)
+	walEnd := pq.LSN(0x16B6D90)
+	data := make([]byte, 25)
+	binary.BigEndian.PutUint64(data[0:], uint64(0x16B6D80)) // WAL start
+	binary.BigEndian.PutUint64(data[8:], uint64(walEnd))    // server WAL end
+	binary.BigEndian.PutUint64(data[16:], 0)                // server time
+	data[24] = 'Z'                                          // unsupported logical message, enough to decode XLogData
+
+	stream.handleXLogData(data, &messageBuffer{outCh: make(chan *Message, 1)}, &streamTxBuffer{})
+
+	assert.Equal(t, walEnd, stream.LoadXLogPos())
+}


### PR DESCRIPTION
## Overview

Standby status updates used `lastXLogPos` as the received WAL position, but `handleXLogData` did not advance that value from the XLogData envelope. This could make status updates report a stale or zero received position even after the client had received newer WAL data.

This PR updates the received WAL position from `XLogData.ServerWALEnd` as soon as an XLogData message is parsed.

## Technical explanation

Logical replication XLogData wraps the logical message payload with WAL start, server WAL end, and server time. The code parsed `ServerWALEnd` but only used it for logging. Later, `SendStandbyStatusUpdate` read `LoadXLogPos()` for the `walReceivedPosition` field.

The change calls `UpdateXLogPos(xld.ServerWALEnd)` before logical message decoding. This keeps the received position aligned with the WAL envelope independently from the confirmed/flush position, which is still advanced by user ACKs.

## Tests

Added `TestHandleXLogDataUpdatesReceivedPosition`, which feeds an XLogData envelope with an unsupported logical payload and verifies that the received WAL position still advances from `ServerWALEnd`.

The test fails without the fix:

```text
mise x go@1.23.2 -- go test ./pq/replication -run TestHandleXLogDataUpdatesReceivedPosition -count=1
```

Validation with the fix:

```text
mise x go@1.23.2 -- go test ./pq/replication
mise x go@1.23.2 -- go test ./...
```
