### PR TITLE
Stop completing snapshot chunks after handler errors

### DIFF
--- a/integration_test/snapshot_handler_error_test.go
+++ b/integration_test/snapshot_handler_error_test.go
@@ -1,0 +1,89 @@
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Trendyol/go-pq-cdc/internal/metric"
+	"github.com/Trendyol/go-pq-cdc/logger"
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/Trendyol/go-pq-cdc/pq/publication"
+	"github.com/Trendyol/go-pq-cdc/pq/snapshot"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotHandlerErrorPreventsChunkCompletion(t *testing.T) {
+	ctx := context.Background()
+	tableName := "snapshot_handler_error_test"
+	slotName := "snapshot_handler_error_slot"
+	cdcCfg := Config
+	cdcCfg.Snapshot.Enabled = true
+	cdcCfg.Snapshot.Mode = "snapshot_only"
+	cdcCfg.Snapshot.ChunkSize = 100
+	cdcCfg.Snapshot.Tables = publication.Tables{
+		{
+			Name:   tableName,
+			Schema: "public",
+		},
+	}
+	cdcCfg.SetDefault()
+	logger.InitLogger(cdcCfg.Logger.Logger)
+
+	postgresConn, err := newPostgresConn()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		postgresConn.Close(ctx)
+		cleanupSnapshotOnlyTestWithID(t, ctx, tableName, slotName)
+	})
+
+	require.NoError(t, createTestTable(ctx, postgresConn, tableName))
+	for i := 1; i <= 2; i++ {
+		query := fmt.Sprintf("INSERT INTO %s(id, name, age) VALUES(%d, 'User%d', %d)",
+			tableName, i, i, 20+i)
+		require.NoError(t, pgExec(ctx, postgresConn, query))
+	}
+
+	snapshotter, err := snapshot.New(ctx, cdcCfg.Snapshot, cdcCfg.Snapshot.Tables, cdcCfg.DSN(), metric.NewMetric(slotName))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		snapshotter.Close(ctx)
+	})
+
+	require.NoError(t, snapshotter.Prepare(ctx, slotName))
+
+	handlerErr := errors.New("downstream write failed")
+	dataEvents := 0
+	err = snapshotter.Execute(ctx, func(event *format.Snapshot) error {
+		if event.EventType == format.SnapshotEventTypeData {
+			dataEvents++
+			return handlerErr
+		}
+		return nil
+	}, slotName)
+	if err != nil {
+		assert.Contains(t, err.Error(), handlerErr.Error())
+	}
+
+	assert.Equal(t, 1, dataEvents, "handler error should stop the failed chunk after the first row")
+
+	jobQuery := fmt.Sprintf("SELECT completed, completed_chunks FROM cdc_snapshot_job WHERE slot_name = '%s'", slotName)
+	jobResults, err := execQuery(ctx, postgresConn, jobQuery)
+	require.NoError(t, err)
+	require.Len(t, jobResults[0].Rows, 1)
+
+	jobRow := jobResults[0].Rows[0]
+	assert.Equal(t, "f", string(jobRow[0]), "job should not be marked completed")
+	assert.Equal(t, "0", string(jobRow[1]), "failed chunk should not count as completed")
+
+	chunkQuery := fmt.Sprintf("SELECT status, rows_processed FROM cdc_snapshot_chunks WHERE slot_name = '%s'", slotName)
+	chunkResults, err := execQuery(ctx, postgresConn, chunkQuery)
+	require.NoError(t, err)
+	require.Len(t, chunkResults[0].Rows, 1)
+
+	chunkRow := chunkResults[0].Rows[0]
+	assert.NotEqual(t, "completed", string(chunkRow[0]), "failed chunk should not be completed")
+	assert.Equal(t, "0", string(chunkRow[1]), "failed chunk should not record processed rows")
+}

--- a/pq/snapshot/coordinator.go
+++ b/pq/snapshot/coordinator.go
@@ -441,7 +441,7 @@ func (s *Snapshotter) processChunk(ctx context.Context, conn pq.Connection, chun
 		isLast := (i == len(result.Rows)-1) && (rowCount < chunk.ChunkSize)
 
 		// Send data event
-		_ = handler(&format.Snapshot{
+		if err := handler(&format.Snapshot{
 			EventType:  format.SnapshotEventTypeData,
 			Table:      chunk.TableName,
 			Schema:     chunk.TableSchema,
@@ -449,7 +449,9 @@ func (s *Snapshotter) processChunk(ctx context.Context, conn pq.Connection, chun
 			ServerTime: chunkTime,
 			LSN:        lsn,
 			IsLast:     isLast,
-		})
+		}); err != nil {
+			return int64(i), errors.Wrap(err, "snapshot handler")
+		}
 	}
 
 	return rowCount, nil


### PR DESCRIPTION
## Overview

Snapshot row handlers can fail after a downstream write or emit error. The row loop previously discarded that error, continued sending the remaining rows, and allowed the chunk to be marked completed.

This PR returns handler errors immediately so failed snapshot rows do not produce completed chunk metadata.

## Technical explanation

`processChunk` now checks the existing inline `handler` call and returns as soon as a snapshot DATA event handler fails. The returned row count reflects only rows completed before the failed handler call, and the error is wrapped with `snapshot handler` for context.

The regression test uses the existing testcontainers-backed integration test setup directly through `snapshot.Snapshotter`. It returns an error from the first DATA event and verifies that only one DATA event is attempted, the job remains incomplete, the chunk is not completed, and `rows_processed` stays at zero.

## Alternatives considered

- Extracting row emission into a helper would allow a lighter unit test, but it refactors `processChunk` for a small bug fix.
- Adding a dedicated worker-level handler error type could make `Execute` fail immediately, but that changes broader chunk error handling and is better handled separately.
- A DB-backed integration regression keeps the production diff small while testing the actual snapshot metadata outcome.

## Tests

- `go test ./...`
- `go test -run TestSnapshotHandlerErrorPreventsChunkCompletion -count=1` from `integration_test`
