### PR TITLE
Close message channel when replication sink exits

### DIFF
--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -60,6 +60,7 @@ type stream struct {
 	messageCH           chan *Message
 	listenerFunc        ListenerFunc
 	sinkEnd             chan struct{}
+	processEnd          chan struct{}
 	mu                  *sync.RWMutex
 	config              config.Config
 	lastXLogPos         pq.LSN
@@ -68,6 +69,8 @@ type stream struct {
 	openFromSnapshotLSN bool
 	closed              atomic.Bool
 	sinkStarted         atomic.Bool
+	processStarted      atomic.Bool
+	messageCloseOnce    sync.Once
 }
 
 func NewStream(dsn string, cfg config.Config, m metric.Metric, listenerFunc ListenerFunc) Streamer {
@@ -83,6 +86,7 @@ func NewStream(dsn string, cfg config.Config, m metric.Metric, listenerFunc List
 		// https://github.com/postgres/postgres/blob/master/src/backend/replication/logical/logical.c#L540
 		lastXLogPos: 0,
 		sinkEnd:     make(chan struct{}, 1),
+		processEnd:  make(chan struct{}, 1),
 		mu:          &sync.RWMutex{},
 	}
 }
@@ -117,8 +121,9 @@ func (s *stream) Open(ctx context.Context) error {
 	}
 
 	s.sinkStarted.Store(true)
-	go s.sink(ctx)
+	s.processStarted.Store(true)
 
+	go s.sink(ctx)
 	go s.process(ctx)
 
 	logger.Info("cdc stream started")
@@ -267,6 +272,9 @@ func (s *stream) sink(ctx context.Context) {
 	buf := &messageBuffer{outCh: s.messageCH}
 	streamBuf := &streamTxBuffer{}
 	corrupted := s.sinkLoop(ctx, buf, streamBuf)
+	s.messageCloseOnce.Do(func() {
+		close(s.messageCH)
+	})
 
 	s.sinkEnd <- struct{}{}
 	if !s.closed.Load() {
@@ -447,44 +455,56 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 
 func (s *stream) process(ctx context.Context) {
 	logger.Info("postgres message process started")
+	defer func() {
+		s.processEnd <- struct{}{}
+	}()
 
 	for {
-		msg, ok := <-s.messageCH
-		if !ok {
-			break
-		}
-
-		ackFunc := func() error {
-			pos := pq.LSN(msg.walStart)
-			s.UpdateConfirmedXLogPos(pos)
-			logger.Debug("send stand by status update", "xLogPos", s.LoadConfirmedXLogPos().String())
-			return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos()))
-		}
-
-		if s.isHeartbeatMessage(msg.message) {
-			if err := ackFunc(); err != nil {
-				logger.Error("heartbeat auto-ack failed", "error", err)
+		select {
+		case <-ctx.Done():
+			logger.Info("postgres message process stopped")
+			return
+		case msg, ok := <-s.messageCH:
+			if !ok {
+				logger.Info("postgres message process stopped")
+				return
 			}
-			continue
-		}
+			if msg == nil {
+				continue
+			}
 
-		lCtx := &ListenerContext{
-			Message: msg.message,
-			Ack:     ackFunc,
-		}
+			ackFunc := func() error {
+				pos := pq.LSN(msg.walStart)
+				s.UpdateConfirmedXLogPos(pos)
+				logger.Debug("send stand by status update", "xLogPos", s.LoadConfirmedXLogPos().String())
+				return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos()))
+			}
 
-		switch lCtx.Message.(type) {
-		case *format.Insert:
-			s.metric.InsertOpIncrement(1)
-		case *format.Delete:
-			s.metric.DeleteOpIncrement(1)
-		case *format.Update:
-			s.metric.UpdateOpIncrement(1)
-		}
+			if s.isHeartbeatMessage(msg.message) {
+				if err := ackFunc(); err != nil {
+					logger.Error("heartbeat auto-ack failed", "error", err)
+				}
+				continue
+			}
 
-		start := time.Now().UTC()
-		s.listenerFunc(lCtx)
-		s.metric.SetProcessLatency(time.Since(start).Nanoseconds())
+			lCtx := &ListenerContext{
+				Message: msg.message,
+				Ack:     ackFunc,
+			}
+
+			switch lCtx.Message.(type) {
+			case *format.Insert:
+				s.metric.InsertOpIncrement(1)
+			case *format.Delete:
+				s.metric.DeleteOpIncrement(1)
+			case *format.Update:
+				s.metric.UpdateOpIncrement(1)
+			}
+
+			start := time.Now().UTC()
+			s.listenerFunc(lCtx)
+			s.metric.SetProcessLatency(time.Since(start).Nanoseconds())
+		}
 	}
 }
 
@@ -514,8 +534,21 @@ func (s *stream) Close(ctx context.Context) {
 	}
 
 	if s.sinkStarted.Load() {
-		<-s.sinkEnd
-		logger.Info("postgres message sink stopped")
+		select {
+		case <-s.sinkEnd:
+			logger.Info("postgres message sink stopped")
+		case <-ctx.Done():
+			logger.Warn("timed out waiting for postgres message sink", "error", ctx.Err())
+		}
+	}
+
+	if s.processStarted.Load() {
+		select {
+		case <-s.processEnd:
+			logger.Info("postgres message process stopped")
+		case <-ctx.Done():
+			logger.Warn("timed out waiting for postgres message process", "error", ctx.Err())
+		}
 	}
 
 	if !s.conn.IsClosed() {

--- a/pq/replication/stream_test.go
+++ b/pq/replication/stream_test.go
@@ -2,11 +2,16 @@ package replication
 
 import (
 	"context"
+	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/Trendyol/go-pq-cdc/config"
 	"github.com/Trendyol/go-pq-cdc/internal/metric"
+	"github.com/Trendyol/go-pq-cdc/logger"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgproto3"
 )
 
 func TestStreamCloseBeforeOpenDoesNotBlock(t *testing.T) {
@@ -31,6 +36,36 @@ func TestStreamCloseAfterOpenFailureDoesNotBlock(t *testing.T) {
 	requireCloseReturns(t, stream, "Close blocked after Open failed before starting the sink")
 }
 
+func TestStreamSinkExitStopsProcessor(t *testing.T) {
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+
+	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(*ListenerContext) {}).(*stream)
+	stream.conn = receiveErrorConn{}
+	// Simulate Close marking the stream closed before ReceiveMessage unblocks.
+	stream.closed.Store(true)
+	stream.processStarted.Store(true)
+
+	go stream.process(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		stream.sink(context.Background())
+	}()
+
+	select {
+	case <-stream.processEnd:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("processor did not stop after sink exited")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("sink did not finish")
+	}
+}
+
 func requireCloseReturns(t *testing.T, stream Streamer, msg string) {
 	t.Helper()
 
@@ -45,4 +80,30 @@ func requireCloseReturns(t *testing.T, stream Streamer, msg string) {
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal(msg)
 	}
+}
+
+type receiveErrorConn struct{}
+
+func (receiveErrorConn) Connect(context.Context) error {
+	return nil
+}
+
+func (receiveErrorConn) IsClosed() bool {
+	return false
+}
+
+func (receiveErrorConn) Close(context.Context) error {
+	return nil
+}
+
+func (receiveErrorConn) ReceiveMessage(context.Context) (pgproto3.BackendMessage, error) {
+	return nil, errors.New("receive failed")
+}
+
+func (receiveErrorConn) Frontend() *pgproto3.Frontend {
+	return nil
+}
+
+func (receiveErrorConn) Exec(context.Context, string) *pgconn.MultiResultReader {
+	return nil
 }


### PR DESCRIPTION
## Overview

When the replication sink exits, the message processor can remain blocked waiting for more messages because `messageCH` is never closed. That leaves the processor goroutine behind after the sink is already done.

This PR closes the message channel when the sink exits and waits for both stream goroutines during `Close`.

## Technical explanation

The stream now tracks the processor lifecycle separately from the sink lifecycle. `sink` closes `messageCH` exactly once after `sinkLoop` returns, which lets `process` exit naturally when no more messages can arrive.

`Close` now waits for the sink and processor with context-aware selects, so shutdown no longer blocks indefinitely if the caller supplies a canceled or timed-out context.

The regression test simulates a sink exit and verifies that the processor stops after the sink closes the message path.

## Alternative considered

A smaller version of this fix would keep the existing `process` loop shape and only make it return when `messageCH` is closed:

```go
for {
	msg, ok := <-s.messageCH
	if !ok {
		logger.Info("postgres message process stopped")
		return
	}

	// existing processing body unchanged
}
```

That would reduce the visual diff because it avoids reindenting the processor body and does not add direct `ctx.Done()` handling inside `process`. The tradeoff is that `process` would still depend on the sink closing `messageCH` to stop; it would not independently exit on context cancellation. The current version is a little more churn, but it gives the processor both shutdown signals: context cancellation and channel closure.

## Tests

- `mise x go@1.23.2 -- go test ./pq/replication`
- `mise x go@1.23.2 -- go test ./...`
