### PR TITLE
Fix TimescaleDB YAML config tag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ type LoggerConfig struct {
 }
 
 type ExtensionSupport struct {
-	EnableTimeScaleDB bool `json:"enableTimeScaleDB" yaml:"EnableTimeScaleDB"`
+	EnableTimeScaleDB bool `json:"enableTimeScaleDB" yaml:"enableTimescaleDB"`
 }
 
 type HeartbeatConfig struct {


### PR DESCRIPTION
## Overview

The README documents the TimescaleDB extension flag as `extensionSupport.enableTimescaleDB`, but the YAML tag currently expects `EnableTimeScaleDB`.

This PR makes the YAML tag match the documented lower-camel-case config key, which also makes it consistent with the JSON key.