### PR TITLE
Add millisecond replication latency metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,8 +356,10 @@ the `/metrics` endpoint.
 | go_pq_cdc_update_total                              | The total number of `UPDATE` operations captured on specific tables.                                  | slot_name, host| Counter    |
 | go_pq_cdc_delete_total                              | The total number of `DELETE` operations captured on specific tables.                                  | slot_name, host| Counter    |
 | go_pq_cdc_insert_total                              | The total number of `INSERT` operations captured on specific tables.                                  | slot_name, host| Counter    |
-| go_pq_cdc_cdc_latency_current                       | The current latency in capturing data changes from PostgreSQL.                                        | slot_name, host| Gauge      |
-| go_pq_cdc_process_latency_current                   | The current latency in processing the captured data changes.                                          | slot_name, host| Gauge      |
+| go_pq_cdc_cdc_latency_current                       | The current latency in capturing data changes from PostgreSQL, in nanoseconds.                       | slot_name, host| Gauge      |
+| go_pq_cdc_cdc_latency_current_milliseconds          | The current latency in capturing data changes from PostgreSQL, in milliseconds.                      | slot_name, host| Gauge      |
+| go_pq_cdc_process_latency_current                   | The current latency in processing the captured data changes, in nanoseconds.                         | slot_name, host| Gauge      |
+| go_pq_cdc_process_latency_current_milliseconds      | The current latency in processing the captured data changes, in milliseconds.                        | slot_name, host| Gauge      |
 | go_pq_cdc_replication_slot_slot_confirmed_flush_lsn | The last confirmed flush Log Sequence Number (LSN) in the PostgreSQL replication slot.                | slot_name, host| Gauge      |
 | go_pq_cdc_replication_slot_slot_current_lsn         | The current Log Sequence Number (LSN) being processed in the PostgreSQL replication slot.             | slot_name, host| Gauge      |
 | go_pq_cdc_replication_slot_slot_is_active           | Indicates whether the PostgreSQL replication slot is currently active (1 for active, 0 for inactive). | slot_name, host| Gauge      |

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	cdcNamespace             = "go_pq_cdc"
-	replicationSlotSubsystem = "replication_slot"
+	cdcNamespace              = "go_pq_cdc"
+	replicationSlotSubsystem  = "replication_slot"
+	nanosecondsPerMillisecond = 1_000_000
 )
 
 type Metric interface {
@@ -42,13 +43,15 @@ type metric struct {
 	totalUpdate prometheus.Counter
 	totalDelete prometheus.Counter
 
-	cdcLatency            prometheus.Gauge
-	processLatency        prometheus.Gauge
-	slotActivity          prometheus.Gauge
-	slotConfirmedFlushLSN prometheus.Gauge
-	slotCurrentLSN        prometheus.Gauge
-	slotRetainedWALSize   prometheus.Gauge
-	slotLag               prometheus.Gauge
+	cdcLatency                 prometheus.Gauge
+	cdcLatencyMilliseconds     prometheus.Gauge
+	processLatency             prometheus.Gauge
+	processLatencyMilliseconds prometheus.Gauge
+	slotActivity               prometheus.Gauge
+	slotConfirmedFlushLSN      prometheus.Gauge
+	slotCurrentLSN             prometheus.Gauge
+	slotRetainedWALSize        prometheus.Gauge
+	slotLag                    prometheus.Gauge
 
 	// Snapshot metrics
 	snapshotInProgress      prometheus.Gauge
@@ -107,11 +110,31 @@ func NewMetric(slotName string) Metric {
 				"host":      hostname,
 			},
 		}),
+		cdcLatencyMilliseconds: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: cdcNamespace,
+			Subsystem: "cdc_latency",
+			Name:      "current_milliseconds",
+			Help:      "latest consumed cdc message latency in milliseconds",
+			ConstLabels: prometheus.Labels{
+				"slot_name": slotName,
+				"host":      hostname,
+			},
+		}),
 		processLatency: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: cdcNamespace,
 			Subsystem: "process_latency",
 			Name:      "current",
 			Help:      "latest cdc process latency",
+			ConstLabels: prometheus.Labels{
+				"slot_name": slotName,
+				"host":      hostname,
+			},
+		}),
+		processLatencyMilliseconds: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: cdcNamespace,
+			Subsystem: "process_latency",
+			Name:      "current_milliseconds",
+			Help:      "latest cdc process latency in milliseconds",
 			ConstLabels: prometheus.Labels{
 				"slot_name": slotName,
 				"host":      hostname,
@@ -256,7 +279,9 @@ func (m *metric) PrometheusCollectors() []prometheus.Collector {
 		m.totalUpdate,
 		m.totalDelete,
 		m.cdcLatency,
+		m.cdcLatencyMilliseconds,
 		m.processLatency,
+		m.processLatencyMilliseconds,
 		m.slotActivity,
 		m.slotCurrentLSN,
 		m.slotConfirmedFlushLSN,
@@ -287,10 +312,12 @@ func (m *metric) DeleteOpIncrement(count int64) {
 
 func (m *metric) SetCDCLatency(latency int64) {
 	m.cdcLatency.Set(float64(latency))
+	m.cdcLatencyMilliseconds.Set(float64(latency) / nanosecondsPerMillisecond)
 }
 
 func (m *metric) SetProcessLatency(latency int64) {
 	m.processLatency.Set(float64(latency))
+	m.processLatencyMilliseconds.Set(float64(latency) / nanosecondsPerMillisecond)
 }
 
 func (m *metric) SetSlotActivity(active bool) {

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -104,7 +104,7 @@ func NewMetric(slotName string) Metric {
 			Namespace: cdcNamespace,
 			Subsystem: "cdc_latency",
 			Name:      "current",
-			Help:      "latest consumed cdc message latency ms",
+			Help:      "latest consumed cdc message latency in nanoseconds",
 			ConstLabels: prometheus.Labels{
 				"slot_name": slotName,
 				"host":      hostname,
@@ -124,7 +124,7 @@ func NewMetric(slotName string) Metric {
 			Namespace: cdcNamespace,
 			Subsystem: "process_latency",
 			Name:      "current",
-			Help:      "latest cdc process latency",
+			Help:      "latest cdc process latency in nanoseconds",
 			ConstLabels: prometheus.Labels{
 				"slot_name": slotName,
 				"host":      hostname,


### PR DESCRIPTION
## Summary

The replication latency metrics are confusing today because the exported values are nanoseconds, while the metric descriptions imply milliseconds.

To keep backward compatibility for existing Prometheus alerts and Grafana dashboards, this PR leaves the existing metrics unchanged:

- `go_pq_cdc_cdc_latency_current`
- `go_pq_cdc_process_latency_current`

It adds explicit millisecond gauges alongside them:

- `go_pq_cdc_cdc_latency_current_milliseconds`
- `go_pq_cdc_process_latency_current_milliseconds`

The existing metric setters still receive nanoseconds and now derive the millisecond values internally. That keeps the replication call sites unchanged and limits the compatibility change to `internal/metric`.

## Tests

- `mise x go@1.23.2 -- go test ./...`
