### PR TITLE
Use EXISTS for snapshot chunk readiness check

### DIFF
--- a/pq/snapshot/worker.go
+++ b/pq/snapshot/worker.go
@@ -76,9 +76,11 @@ func (s *Snapshotter) isCoordinatorDidItsJob(ctx context.Context, slotName strin
 // hasChunksReady checks if there are chunks available for processing
 func (s *Snapshotter) hasChunksReady(ctx context.Context, slotName string) (bool, error) {
 	query := fmt.Sprintf(`
-		SELECT COUNT(*) > 0 
-		FROM %s 
-		WHERE slot_name = '%s'
+		SELECT EXISTS (
+			SELECT 1
+			FROM %s
+			WHERE slot_name = '%s'
+		)
 	`, chunksTableName, slotName)
 
 	results, err := s.execQuery(ctx, s.metadataConn, query)


### PR DESCRIPTION
## Summary

The snapshot worker readiness check only needs to know whether at least one chunk exists for the slot. `COUNT(*) > 0` can require counting all matching rows, while `EXISTS` lets PostgreSQL stop as soon as it finds the first match.

This keeps the same boolean result while making the coordinator polling query cheaper when a snapshot has many chunks.

## Tests

- `mise x go@1.23.2 -- go test ./pq/snapshot`
- `mise x go@1.23.2 -- go test ./...`