### PR TITLE
Parse snapshot metadata integers with strconv

### DIFF
--- a/pq/snapshot/coordinator.go
+++ b/pq/snapshot/coordinator.go
@@ -1210,7 +1210,8 @@ func (s *Snapshotter) getTableRawCountWithConn(ctx context.Context, conn pq.Conn
 	}
 
 	var count int64
-	if _, err := fmt.Sscanf(countStr, "%d", &count); err != nil {
+	count, err = strconv.ParseInt(countStr, 10, 64)
+	if err != nil {
 		return 0, errors.Wrap(err, "parse row count")
 	}
 

--- a/pq/snapshot/job.go
+++ b/pq/snapshot/job.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/Trendyol/go-pq-cdc/pq"
@@ -117,10 +118,12 @@ func (s *Snapshotter) loadJob(ctx context.Context, slotName string) (*Job, error
 		}
 
 		job.Completed = string(row[4]) == "t" || string(row[4]) == "true"
-		if _, err := fmt.Sscanf(string(row[5]), "%d", &job.TotalChunks); err != nil {
+		job.TotalChunks, err = strconv.Atoi(string(row[5]))
+		if err != nil {
 			return errors.Wrap(err, "parse total chunks")
 		}
-		if _, err := fmt.Sscanf(string(row[6]), "%d", &job.CompletedChunks); err != nil {
+		job.CompletedChunks, err = strconv.Atoi(string(row[6]))
+		if err != nil {
 			return errors.Wrap(err, "parse completed chunks")
 		}
 
@@ -160,10 +163,12 @@ func (s *Snapshotter) checkJobCompleted(ctx context.Context, slotName string) (b
 
 		row := results[0].Rows[0]
 		var total, completed int
-		if _, err := fmt.Sscanf(string(row[0]), "%d", &total); err != nil {
+		total, err = strconv.Atoi(string(row[0]))
+		if err != nil {
 			return errors.Wrap(err, "parse total count")
 		}
-		if _, err := fmt.Sscanf(string(row[1]), "%d", &completed); err != nil {
+		completed, err = strconv.Atoi(string(row[1]))
+		if err != nil {
 			return errors.Wrap(err, "parse completed count")
 		}
 

--- a/pq/snapshot/worker.go
+++ b/pq/snapshot/worker.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/Trendyol/go-pq-cdc/logger"
@@ -496,18 +497,23 @@ func (s *Snapshotter) parseClaimedChunk(row [][]byte, slotName, instanceID strin
 	}
 
 	// Parse each field with validation
-	if _, err := fmt.Sscanf(string(row[0]), "%d", &chunk.ID); err != nil {
+	var err error
+	chunk.ID, err = strconv.ParseInt(string(row[0]), 10, 64)
+	if err != nil {
 		return nil, errors.Wrap(err, "parse chunk ID")
 	}
 	chunk.TableSchema = string(row[1])
 	chunk.TableName = string(row[2])
-	if _, err := fmt.Sscanf(string(row[3]), "%d", &chunk.ChunkIndex); err != nil {
+	chunk.ChunkIndex, err = strconv.Atoi(string(row[3]))
+	if err != nil {
 		return nil, errors.Wrap(err, "parse chunk index")
 	}
-	if _, err := fmt.Sscanf(string(row[4]), "%d", &chunk.ChunkStart); err != nil {
+	chunk.ChunkStart, err = strconv.ParseInt(string(row[4]), 10, 64)
+	if err != nil {
 		return nil, errors.Wrap(err, "parse chunk start")
 	}
-	if _, err := fmt.Sscanf(string(row[5]), "%d", &chunk.ChunkSize); err != nil {
+	chunk.ChunkSize, err = strconv.ParseInt(string(row[5]), 10, 64)
+	if err != nil {
 		return nil, errors.Wrap(err, "parse chunk size")
 	}
 


### PR DESCRIPTION
## Summary

Snapshot metadata parsing currently uses `fmt.Sscanf` for integer fields loaded from metadata queries. These fields are plain base-10 values, so `strconv.Atoi` and `strconv.ParseInt` are simpler and avoid the format-scanning overhead.

This PR keeps the same parsed types and error wrapping while using direct integer parsers in the snapshot job, chunk, and row-count paths.

## Tests

- `mise x go@1.23.2 -- go test ./pq/snapshot`
- `mise x go@1.23.2 -- go test ./...`