### PR TITLE
Fix no-walsender snapshot test race

### DIFF
--- a/integration_test/snapshot_no_walsender_test.go
+++ b/integration_test/snapshot_no_walsender_test.go
@@ -64,6 +64,7 @@ func TestNoWalsenderDuringSnapshot(t *testing.T) {
 	maxWalsendersDuringSnapshot := 0
 	var snapshotInProgress atomic.Bool
 	stopWalsenderCheck := make(chan struct{})
+	walsenderCheckDone := make(chan struct{})
 
 	messageCh := make(chan any, 200)
 	handlerFunc := func(ctx *replication.ListenerContext) {
@@ -93,6 +94,8 @@ func TestNoWalsenderDuringSnapshot(t *testing.T) {
 
 	// Background goroutine to check walsender count during snapshot
 	go func() {
+		defer close(walsenderCheckDone)
+
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 
@@ -101,18 +104,23 @@ func TestNoWalsenderDuringSnapshot(t *testing.T) {
 			case <-stopWalsenderCheck:
 				return
 			case <-ticker.C:
-				if snapshotInProgress.Load() {
-					count, err := countWalsendersForSlot(ctx, checkConn, cdcCfg.Slot.Name)
-					if err != nil {
-						t.Logf("⚠️  Failed to count walsenders: %v", err)
-						continue
-					}
-					if count > maxWalsendersDuringSnapshot {
-						maxWalsendersDuringSnapshot = count
-					}
-					if count > 0 {
-						t.Logf("⚠️  Walsender detected during snapshot: count=%d", count)
-					}
+				if !snapshotInProgress.Load() {
+					continue
+				}
+
+				count, err := countWalsendersForSlot(ctx, checkConn, cdcCfg.Slot.Name)
+				if err != nil {
+					t.Logf("⚠️  Failed to count walsenders: %v", err)
+					continue
+				}
+				if !snapshotInProgress.Load() {
+					continue
+				}
+				if count > maxWalsendersDuringSnapshot {
+					maxWalsendersDuringSnapshot = count
+				}
+				if count > 0 {
+					t.Logf("⚠️  Walsender detected during snapshot: count=%d", count)
 				}
 			}
 		}
@@ -158,6 +166,7 @@ func TestNoWalsenderDuringSnapshot(t *testing.T) {
 
 	// Stop walsender checking
 	close(stopWalsenderCheck)
+	<-walsenderCheckDone
 
 	// Wait a bit for CDC to start
 	time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
## Summary
`TestNoWalsenderDuringSnapshot` can report a false positive when the background walsender checker starts a `pg_stat_replication` query while `snapshotInProgress` is true, but the snapshot completes before the query result is recorded. At that point CDC streaming may have legitimately opened its walsender, so recording that result as a during-snapshot count makes the test fail even though the production behavior is correct.

This updates the checker to re-read `snapshotInProgress` after the query returns and ignore counts that raced with snapshot completion. It also waits for the checker goroutine to exit after closing `stopWalsenderCheck` before the test reads `maxWalsendersDuringSnapshot` or reuses the same check connection for the after-snapshot assertion. That removes the bookkeeping race and keeps the test synchronized under `-race`.

I verified the upstream test behavior before changing the final code: the unmodified test passed `50/50` locally, but GitHub Actions already captured the natural failure on #126. To validate the root cause locally, I used this temporary timing stress, which reproduced the same `maxWalsendersDuringSnapshot = 1` failure before the fix and passed after this synchronization change:

```diff
diff --git a/integration_test/snapshot_no_walsender_test.go b/integration_test/snapshot_no_walsender_test.go
index dc74632..7d71a8e 100644
--- a/integration_test/snapshot_no_walsender_test.go
+++ b/integration_test/snapshot_no_walsender_test.go
@@ -102,6 +102,7 @@ func TestNoWalsenderDuringSnapshot(t *testing.T) {
 				return
 			case <-ticker.C:
 				if snapshotInProgress.Load() {
+					time.Sleep(200 * time.Millisecond)
 					count, err := countWalsendersForSlot(ctx, checkConn, cdcCfg.Slot.Name)
 					if err != nil {
 						t.Logf("⚠️  Failed to count walsenders: %v", err)
@@ -138,6 +139,7 @@ func TestNoWalsenderDuringSnapshot(t *testing.T) {
 				case format.SnapshotEventTypeBegin:
 					snapshotBeginReceived = true
 					snapshotInProgress.Store(true)
+					time.Sleep(2 * time.Second)
 					t.Logf("✅ Snapshot BEGIN received, LSN: %s", m.LSN.String())
 				case format.SnapshotEventTypeData:
 					snapshotDataCount++
```

The timing stress was removed from this PR.

## Tests
```sh
POSTGRES_VERSION=15-alpine go test -race -p=1 -v ./... -run TestNoWalsenderDuringSnapshot -count=10
```
