### PR TITLE
add LSN to insert/update/delete messages

### DIFF
--- a/pq/message/format/delete.go
+++ b/pq/message/format/delete.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"time"
 
+	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/Trendyol/go-pq-cdc/pq/message/tuple"
 	"github.com/go-playground/errors"
 )
@@ -14,6 +15,7 @@ type Delete struct {
 	OldDecoded     map[string]any
 	TableNamespace string
 	TableName      string
+	LSN            pq.LSN
 	OID            uint32
 	XID            uint32
 	OldTupleType   uint8

--- a/pq/message/format/insert.go
+++ b/pq/message/format/insert.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"time"
 
+	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/Trendyol/go-pq-cdc/pq/message/tuple"
 	"github.com/go-playground/errors"
 )
@@ -18,6 +19,7 @@ type Insert struct {
 	Decoded        map[string]any
 	TableNamespace string
 	TableName      string
+	LSN            pq.LSN
 	OID            uint32
 	XID            uint32
 }

--- a/pq/message/format/update.go
+++ b/pq/message/format/update.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"time"
 
+	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/Trendyol/go-pq-cdc/pq/message/tuple"
 	"github.com/go-playground/errors"
 )
@@ -22,6 +23,7 @@ type Update struct {
 	OldDecoded     map[string]any
 	TableNamespace string
 	TableName      string
+	LSN            pq.LSN
 	OID            uint32
 	XID            uint32
 	OldTupleType   uint8

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -392,6 +392,16 @@ func (s *stream) handleXLogData(data []byte, buf *messageBuffer, streamBuf *stre
 		return
 	}
 
+	// add LSN to insert/update/delete messages
+	switch m := decodedMsg.(type) {
+	case *format.Insert:
+		m.LSN = xld.WALStart
+	case *format.Update:
+		m.LSN = xld.WALStart
+	case *format.Delete:
+		m.LSN = xld.WALStart
+	}
+
 	s.dispatchMessage(decodedMsg, xld, buf, streamBuf)
 }
 


### PR DESCRIPTION
Debezium messages have the LSN per record for insert/update/delete events. This is just to replicate that behavior with minimal changes. Snapshot messages already have this field just adding it to the others.

We use the LSN value in downstream data processing in the case that events come in at the same or very close timestamps. 