### PR TITLE
Add transaction-aware listener API

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Snapshot         SnapshotConfig     `json:"snapshot" yaml:"snapshot"`
 	Port             int                `json:"port" yaml:"port"`
 	Metric           MetricConfig       `json:"metric" yaml:"metric"`
+	Listener         ListenerConfig     `json:"listener" yaml:"listener"`
 	DebugMode        bool               `json:"debugMode" yaml:"debugMode"`
 	ExtensionSupport ExtensionSupport   `json:"extensionSupport" yaml:"extensionSupport"`
 }
@@ -48,6 +49,10 @@ type ExtensionSupport struct {
 type HeartbeatConfig struct {
 	Table    publication.Table `json:"table" yaml:"table"`
 	Interval time.Duration     `json:"interval" yaml:"interval"`
+}
+
+type ListenerConfig struct {
+	EmitTransactionBoundaries bool `json:"emitTransactionBoundaries" yaml:"emitTransactionBoundaries"`
 }
 
 // DSN returns a normal PostgreSQL connection string for regular database operations

--- a/docs/TRANSACTION_AWARE_LISTENER_API.md
+++ b/docs/TRANSACTION_AWARE_LISTENER_API.md
@@ -1,0 +1,125 @@
+# Transaction-Aware Listener Metadata API
+
+## Summary
+
+`go-pq-cdc` works well for row-oriented consumers, but some consumers need a stronger listener contract: they need to project a full committed PostgreSQL transaction atomically, persist the commit/checkpoint LSN, and only acknowledge replication after their projection is durable.
+
+This adds an opt-in transaction-aware listener mode that exposes WAL metadata and transaction boundary events to the listener.
+
+The default row-oriented behavior remains unchanged for existing users.
+
+## Problem
+
+The current listener callback receives decoded messages and an `Ack` function. For transactional projectors, that is not enough.
+
+A consumer that maintains a derived read model or sync log often needs to:
+
+- group all row changes from one PostgreSQL transaction
+- apply those changes atomically to its own tables
+- store the transaction commit LSN as an idempotency/checkpoint key
+- call `Ack()` only after the whole projected transaction commits
+- avoid acknowledging partial transaction state
+
+Without explicit transaction boundary events, the consumer cannot reliably know when to flush an accumulated transaction. Without exposed WAL metadata, it also cannot persist the exact source position associated with a row or commit.
+
+This is generic CDC behavior, not application-specific mapping logic.
+
+## API
+
+Add WAL metadata to listener contexts:
+
+```go
+type ListenerContext struct {
+	Message any
+	Ack     func() error
+
+	// WALStart is the WAL start position for this decoded logical message.
+	WALStart pq.LSN
+
+	// AckLSN is the exact LSN that Ack will confirm.
+	// For commit events this is the transaction end LSN.
+	AckLSN pq.LSN
+}
+```
+
+Add an opt-in config flag:
+
+```go
+type ListenerConfig struct {
+	EmitTransactionBoundaries bool `json:"emitTransactionBoundaries" yaml:"emitTransactionBoundaries"`
+}
+```
+
+When `EmitTransactionBoundaries` is false, behavior remains row-oriented.
+
+When `EmitTransactionBoundaries` is true, the listener receives:
+
+- `*format.Begin`
+- row messages: `*format.Insert`, `*format.Update`, `*format.Delete`
+- `*format.Commit`
+- buffered streamed transaction rows followed by `*format.StreamCommit`
+- snapshot events as they work today
+
+## Semantics
+
+For regular transactions:
+
+1. Emit `Begin`.
+2. Emit row events in WAL/order-preserving order.
+3. Emit `Commit`.
+4. `Commit.Ack()` confirms the transaction end LSN.
+
+For streamed transactions:
+
+1. Do not emit rows before the streamed transaction commits.
+2. Buffer streamed rows by XID as today.
+3. On `StreamCommit`, emit the buffered rows in order.
+4. Emit `StreamCommit`.
+5. `StreamCommit.Ack()` confirms the transaction end LSN.
+6. On `StreamAbort`, discard buffered rows and emit nothing.
+
+For rollbacks:
+
+- no committed row events are emitted
+- no commit boundary is emitted
+
+## Why This Matters
+
+This enables downstream systems to implement correct transactional projection:
+
+```go
+func listener(ctx *replication.ListenerContext) {
+	switch msg := ctx.Message.(type) {
+	case *format.Begin:
+		txBuffer.Begin(msg.Xid)
+
+	case *format.Insert, *format.Update, *format.Delete:
+		txBuffer.Append(ctx.WALStart, msg)
+
+	case *format.Commit:
+		if err := projector.Apply(txBuffer.Rows(), msg.TransactionEndLSN); err != nil {
+			return
+		}
+		_ = ctx.Ack()
+	}
+}
+```
+
+The important property is that replication is acknowledged only after the consumer has durably applied the full source transaction.
+
+## Test Coverage
+
+Covered behavior:
+
+- default mode does not emit transaction boundary messages
+- transaction mode emits `Begin -> rows -> Commit`
+- `Commit` context has `AckLSN == TransactionEndLSN`
+- multi-row transactions preserve row order
+- streamed transactions emit no rows before `StreamCommit`
+- `StreamAbort` discards buffered rows
+- listener can delay `Ack()` until after commit projection
+- sink shutdown closes/stops processor cleanly without blocking
+
+## Compatibility
+
+This is introduced as an opt-in feature. Existing users that only handle row messages keep the current default behavior. Transactional consumers get a stable API instead of relying on internal buffering details.

--- a/docs/TRANSACTION_AWARE_LISTENER_API.md
+++ b/docs/TRANSACTION_AWARE_LISTENER_API.md
@@ -36,8 +36,9 @@ type ListenerContext struct {
 	// WALStart is the WAL start position for this decoded logical message.
 	WALStart pq.LSN
 
-	// AckLSN is the exact LSN that Ack will confirm.
-	// For commit events this is the transaction end LSN.
+	// AckLSN is the LSN associated with this message's acknowledgement.
+	// In transaction-aware mode, only Commit and StreamCommit acknowledgements
+	// advance confirmed_flush_lsn; non-commit acknowledgements are non-advancing.
 	AckLSN pq.LSN
 }
 ```
@@ -55,9 +56,9 @@ When `EmitTransactionBoundaries` is false, behavior remains row-oriented.
 When `EmitTransactionBoundaries` is true, the listener receives:
 
 - `*format.Begin`
-- row messages: `*format.Insert`, `*format.Update`, `*format.Delete`
+- decoded row and metadata messages in WAL order, such as `*format.Insert`, `*format.Update`, `*format.Delete`, `*format.Relation`, and `*format.Truncate` when PostgreSQL emits them
 - `*format.Commit`
-- buffered streamed transaction rows followed by `*format.StreamCommit`
+- buffered streamed transaction messages followed by `*format.StreamCommit`
 - snapshot events as they work today
 
 ## Semantics
@@ -65,23 +66,32 @@ When `EmitTransactionBoundaries` is true, the listener receives:
 For regular transactions:
 
 1. Emit `Begin`.
-2. Emit row events in WAL/order-preserving order.
+2. Emit decoded row and metadata events in WAL/order-preserving order.
 3. Emit `Commit`.
-4. `Commit.Ack()` confirms the transaction end LSN.
+4. `Ack()` on `Commit` is the transaction checkpoint acknowledgement.
 
 For streamed transactions:
 
-1. Do not emit rows before the streamed transaction commits.
-2. Buffer streamed rows by XID as today.
-3. On `StreamCommit`, emit the buffered rows in order.
+1. Do not emit streamed transaction messages before the streamed transaction commits.
+2. Buffer streamed messages by XID as today.
+3. On `StreamCommit`, emit the buffered messages in order.
 4. Emit `StreamCommit`.
-5. `StreamCommit.Ack()` confirms the transaction end LSN.
-6. On `StreamAbort`, discard buffered rows and emit nothing.
+5. `Ack()` on `StreamCommit` is the transaction checkpoint acknowledgement.
+6. On `StreamAbort`, discard buffered messages and emit nothing.
 
 For rollbacks:
 
 - no committed row events are emitted
 - no commit boundary is emitted
+
+For acknowledgements in transaction-aware mode:
+
+- `Ack()` on `Commit` and `StreamCommit` is the only operation that may advance `confirmed_flush_lsn`.
+- `Ack()` on non-commit messages sends a standby status update with the current confirmed LSN, but does not advance `confirmed_flush_lsn`, even when the message's `AckLSN` is a transaction-end LSN.
+- Commit acknowledgements are ordered. A later commit acknowledgement is held behind any earlier unacknowledged commit, so a later `Ack()` cannot accidentally confirm an unprojected earlier transaction.
+- `Ack()` is still cumulative at the PostgreSQL replication-slot level. Transaction-aware mode adds an ordered checkpoint guard around commit acknowledgements; consumers must still retry, block, stop the connector, or terminate the process after a projection failure instead of continuing to process later commits.
+
+Heartbeat rows are still filtered before delivery. In transaction-aware mode, heartbeat row auto-acks are non-advancing. Boundary messages around heartbeat transactions may still be visible; consumers should acknowledge every visible commit boundary or disable heartbeat for that listener mode.
 
 ## Why This Matters
 
@@ -97,10 +107,15 @@ func listener(ctx *replication.ListenerContext) {
 		txBuffer.Append(ctx.WALStart, msg)
 
 	case *format.Commit:
-		if err := projector.Apply(txBuffer.Rows(), msg.TransactionEndLSN); err != nil {
+		if err := projector.Apply(txBuffer.Rows(), ctx.AckLSN); err != nil {
+			// Do not continue to later commits after a failed projection.
+			// Retry, block, cancel the connector, or terminate the process.
+			failHard(err)
 			return
 		}
-		_ = ctx.Ack()
+		if err := ctx.Ack(); err != nil {
+			failHard(err)
+		}
 	}
 }
 ```
@@ -112,8 +127,11 @@ The important property is that replication is acknowledged only after the consum
 Covered behavior:
 
 - default mode does not emit transaction boundary messages
+- default mode keeps immediate row-oriented acknowledgement behavior
 - transaction mode emits `Begin -> rows -> Commit`
 - `Commit` context has `AckLSN == TransactionEndLSN`
+- non-commit `Ack()` does not advance `confirmed_flush_lsn` in transaction-aware mode
+- later commit acknowledgements cannot advance past an earlier unacknowledged commit in transaction-aware mode
 - multi-row transactions preserve row order
 - streamed transactions emit no rows before `StreamCommit`
 - `StreamAbort` discards buffered rows

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -181,8 +181,8 @@ func (b *messageBuffer) flush() {
 	}
 }
 
-// flushWithLSN emits the pending message (if any), rewriting its WAL position
-// to the given transaction-end LSN. Used at COMMIT.
+// flushWithLSN emits the pending message, preserving its WALStart while setting
+// AckLSN to the transaction-end LSN.
 func (b *messageBuffer) flushWithLSN(lsn pq.LSN) {
 	if b.pending != nil {
 		b.outCh <- &Message{
@@ -245,7 +245,8 @@ func (s *streamTxBuffer) stopTx() {
 }
 
 // flushTx emits every accumulated message for the given XID through outCh.
-// The last message's WAL position is rewritten to the transaction-end LSN.
+// The last message's WALStart is preserved while its AckLSN is set to the
+// transaction-end LSN.
 func (s *streamTxBuffer) flushTx(xid uint32, outCh chan<- *Message, endLSN pq.LSN) {
 	s.streaming = false
 	msgs := s.txns[xid]
@@ -482,6 +483,8 @@ func (s *stream) process(ctx context.Context) {
 		s.processEnd <- struct{}{}
 	}()
 
+	ackTracker := newTransactionAckTracker()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -496,12 +499,7 @@ func (s *stream) process(ctx context.Context) {
 				continue
 			}
 
-			ackFunc := func() error {
-				s.UpdateConfirmedXLogPos(msg.ackLSN)
-				logger.Debug("send stand by status update", "xLogPos", s.LoadConfirmedXLogPos().String())
-				return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos()))
-			}
-
+			ackFunc := s.ackFuncForMessage(ctx, msg, ackTracker)
 			if s.isHeartbeatMessage(msg.message) {
 				if err := ackFunc(); err != nil {
 					logger.Error("heartbeat auto-ack failed", "error", err)
@@ -530,6 +528,88 @@ func (s *stream) process(ctx context.Context) {
 			s.metric.SetProcessLatency(time.Since(start).Nanoseconds())
 		}
 	}
+}
+
+type transactionAckCheckpoint struct {
+	lsn   pq.LSN
+	acked bool
+}
+
+type transactionAckTracker struct {
+	checkpoints []*transactionAckCheckpoint
+	mu          sync.Mutex
+}
+
+func newTransactionAckTracker() *transactionAckTracker {
+	return &transactionAckTracker{}
+}
+
+func (t *transactionAckTracker) register(lsn pq.LSN) *transactionAckCheckpoint {
+	checkpoint := &transactionAckCheckpoint{lsn: lsn}
+	t.mu.Lock()
+	t.checkpoints = append(t.checkpoints, checkpoint)
+	t.mu.Unlock()
+	return checkpoint
+}
+
+func (t *transactionAckTracker) ack(checkpoint *transactionAckCheckpoint, advance func(pq.LSN)) {
+	if checkpoint == nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	checkpoint.acked = true
+	for len(t.checkpoints) > 0 && t.checkpoints[0].acked {
+		advance(t.checkpoints[0].lsn)
+		t.checkpoints = t.checkpoints[1:]
+	}
+}
+
+func (s *stream) ackFuncForMessage(ctx context.Context, msg *Message, tracker *transactionAckTracker) func() error {
+	if !s.config.Listener.EmitTransactionBoundaries {
+		return s.advancingAckFunc(ctx, msg)
+	}
+	if isTransactionCommitBoundary(msg.message) {
+		checkpoint := tracker.register(msg.ackLSN)
+		return s.orderedCommitAckFunc(ctx, msg, tracker, checkpoint)
+	}
+	return s.nonAdvancingAckFunc(ctx, msg)
+}
+
+func isTransactionCommitBoundary(msg any) bool {
+	switch msg.(type) {
+	case *format.Commit, *format.StreamCommit:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *stream) advancingAckFunc(ctx context.Context, msg *Message) func() error {
+	return func() error {
+		s.UpdateConfirmedXLogPos(msg.ackLSN)
+		return s.sendStandbyStatusUpdate(ctx, msg)
+	}
+}
+
+func (s *stream) orderedCommitAckFunc(ctx context.Context, msg *Message, tracker *transactionAckTracker, checkpoint *transactionAckCheckpoint) func() error {
+	return func() error {
+		tracker.ack(checkpoint, s.UpdateConfirmedXLogPos)
+		return s.sendStandbyStatusUpdate(ctx, msg)
+	}
+}
+
+func (s *stream) nonAdvancingAckFunc(ctx context.Context, msg *Message) func() error {
+	return func() error {
+		return s.sendStandbyStatusUpdate(ctx, msg)
+	}
+}
+
+func (s *stream) sendStandbyStatusUpdate(ctx context.Context, msg *Message) error {
+	logger.Debug("send stand by status update", "xLogPos", s.LoadConfirmedXLogPos().String(), "ackLSN", msg.ackLSN.String())
+	return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos()))
 }
 
 func (s *stream) isHeartbeatMessage(msg any) bool {

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -31,15 +31,18 @@ const (
 )
 
 type ListenerContext struct {
-	Message any
-	Ack     func() error
+	Message  any
+	Ack      func() error
+	WALStart pq.LSN
+	AckLSN   pq.LSN
 }
 
 type ListenerFunc func(ctx *ListenerContext)
 
 type Message struct {
 	message  any
-	walStart int64
+	walStart pq.LSN
+	ackLSN   pq.LSN
 }
 
 type Streamer interface {
@@ -184,7 +187,8 @@ func (b *messageBuffer) flushWithLSN(lsn pq.LSN) {
 	if b.pending != nil {
 		b.outCh <- &Message{
 			message:  b.pending.message,
-			walStart: int64(lsn),
+			walStart: b.pending.walStart,
+			ackLSN:   lsn,
 		}
 		b.pending = nil
 	}
@@ -250,7 +254,8 @@ func (s *streamTxBuffer) flushTx(xid uint32, outCh chan<- *Message, endLSN pq.LS
 		if i == n-1 {
 			outCh <- &Message{
 				message:  msg.message,
-				walStart: int64(endLSN),
+				walStart: msg.walStart,
+				ackLSN:   endLSN,
 			}
 		} else {
 			outCh <- msg
@@ -426,9 +431,15 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 	switch msg := decodedMsg.(type) {
 	case *format.Begin:
 		buf.discard()
+		if s.config.Listener.EmitTransactionBoundaries {
+			buf.outCh <- &Message{message: msg, walStart: xld.WALStart, ackLSN: xld.WALStart}
+		}
 
 	case *format.Commit:
 		buf.flushWithLSN(msg.TransactionEndLSN)
+		if s.config.Listener.EmitTransactionBoundaries {
+			buf.outCh <- &Message{message: msg, walStart: xld.WALStart, ackLSN: msg.TransactionEndLSN}
+		}
 
 	case *format.StreamStart:
 		// Beginning of a streaming chunk – DML events that follow belong
@@ -442,6 +453,9 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 	case *format.StreamCommit:
 		// Final commit of a streamed transaction – emit all messages for this XID.
 		streamBuf.flushTx(msg.Xid, buf.outCh, msg.TransactionEndLSN)
+		if s.config.Listener.EmitTransactionBoundaries {
+			buf.outCh <- &Message{message: msg, walStart: xld.WALStart, ackLSN: msg.TransactionEndLSN}
+		}
 
 	case *format.StreamAbort:
 		// Streamed transaction rolled back – discard messages for this XID.
@@ -451,7 +465,8 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 		// DML event (Insert, Update, Delete, Relation, …)
 		m := &Message{
 			message:  decodedMsg,
-			walStart: int64(xld.WALStart),
+			walStart: xld.WALStart,
+			ackLSN:   xld.WALStart,
 		}
 		if streamBuf.streaming {
 			streamBuf.append(m)
@@ -482,8 +497,7 @@ func (s *stream) process(ctx context.Context) {
 			}
 
 			ackFunc := func() error {
-				pos := pq.LSN(msg.walStart)
-				s.UpdateConfirmedXLogPos(pos)
+				s.UpdateConfirmedXLogPos(msg.ackLSN)
 				logger.Debug("send stand by status update", "xLogPos", s.LoadConfirmedXLogPos().String())
 				return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos()))
 			}
@@ -496,8 +510,10 @@ func (s *stream) process(ctx context.Context) {
 			}
 
 			lCtx := &ListenerContext{
-				Message: msg.message,
-				Ack:     ackFunc,
+				Message:  msg.message,
+				WALStart: msg.walStart,
+				AckLSN:   msg.ackLSN,
+				Ack:      ackFunc,
 			}
 
 			switch lCtx.Message.(type) {

--- a/pq/replication/stream_listener_test.go
+++ b/pq/replication/stream_listener_test.go
@@ -1,0 +1,125 @@
+package replication
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/internal/metric"
+	"github.com/Trendyol/go-pq-cdc/pq"
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+)
+
+func TestDispatchDefaultKeepsRowOrientedListenerContract(t *testing.T) {
+	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(*ListenerContext) {}).(*stream)
+	out := make(chan *Message, 4)
+	buf := &messageBuffer{outCh: out}
+	streamBuf := &streamTxBuffer{}
+
+	stream.dispatchMessage(&format.Begin{FinalLSN: pq.LSN(19)}, XLogData{WALStart: pq.LSN(10)}, buf, streamBuf)
+	stream.dispatchMessage(&format.Insert{TableName: "books"}, XLogData{WALStart: pq.LSN(11)}, buf, streamBuf)
+	stream.dispatchMessage(&format.Commit{TransactionEndLSN: pq.LSN(20)}, XLogData{WALStart: pq.LSN(20)}, buf, streamBuf)
+
+	requireMessageCount(t, out, 1)
+	msg := <-out
+	if _, ok := msg.message.(*format.Insert); !ok {
+		t.Fatalf("message = %T, want *format.Insert", msg.message)
+	}
+	if msg.walStart != pq.LSN(11) {
+		t.Fatalf("walStart = %s, want 0/B", msg.walStart)
+	}
+	if msg.ackLSN != pq.LSN(20) {
+		t.Fatalf("ackLSN = %s, want 0/14", msg.ackLSN)
+	}
+}
+
+func TestDispatchCanEmitTransactionBoundaries(t *testing.T) {
+	cfg := config.Config{Listener: config.ListenerConfig{EmitTransactionBoundaries: true}}
+	stream := NewStream("", cfg, metric.NewMetric("test_slot"), func(*ListenerContext) {}).(*stream)
+	out := make(chan *Message, 8)
+	buf := &messageBuffer{outCh: out}
+	streamBuf := &streamTxBuffer{}
+
+	stream.dispatchMessage(&format.Begin{FinalLSN: pq.LSN(19)}, XLogData{WALStart: pq.LSN(10)}, buf, streamBuf)
+	stream.dispatchMessage(&format.Insert{TableName: "books"}, XLogData{WALStart: pq.LSN(11)}, buf, streamBuf)
+	stream.dispatchMessage(&format.Update{TableName: "books"}, XLogData{WALStart: pq.LSN(12)}, buf, streamBuf)
+	stream.dispatchMessage(&format.Commit{TransactionEndLSN: pq.LSN(20)}, XLogData{WALStart: pq.LSN(13)}, buf, streamBuf)
+
+	requireMessageCount(t, out, 4)
+	assertMessage[*format.Begin](t, <-out, pq.LSN(10), pq.LSN(10))
+	assertMessage[*format.Insert](t, <-out, pq.LSN(11), pq.LSN(11))
+	assertMessage[*format.Update](t, <-out, pq.LSN(12), pq.LSN(20))
+	assertMessage[*format.Commit](t, <-out, pq.LSN(13), pq.LSN(20))
+}
+
+func TestDispatchCanEmitStreamCommitBoundary(t *testing.T) {
+	cfg := config.Config{Listener: config.ListenerConfig{EmitTransactionBoundaries: true}}
+	stream := NewStream("", cfg, metric.NewMetric("test_slot"), func(*ListenerContext) {}).(*stream)
+	out := make(chan *Message, 8)
+	buf := &messageBuffer{outCh: out}
+	streamBuf := &streamTxBuffer{}
+
+	stream.dispatchMessage(&format.StreamStart{Xid: 7}, XLogData{WALStart: pq.LSN(30)}, buf, streamBuf)
+	stream.dispatchMessage(&format.Insert{TableName: "books"}, XLogData{WALStart: pq.LSN(31)}, buf, streamBuf)
+	stream.dispatchMessage(&format.StreamStop{}, XLogData{WALStart: pq.LSN(32)}, buf, streamBuf)
+	stream.dispatchMessage(&format.StreamCommit{Xid: 7, TransactionEndLSN: pq.LSN(40)}, XLogData{WALStart: pq.LSN(33)}, buf, streamBuf)
+
+	requireMessageCount(t, out, 2)
+	assertMessage[*format.Insert](t, <-out, pq.LSN(31), pq.LSN(40))
+	assertMessage[*format.StreamCommit](t, <-out, pq.LSN(33), pq.LSN(40))
+}
+
+func TestProcessExposesWALMetadataToListener(t *testing.T) {
+	received := make(chan ListenerContext, 1)
+	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(ctx *ListenerContext) {
+		received <- ListenerContext{
+			Message:  ctx.Message,
+			WALStart: ctx.WALStart,
+			AckLSN:   ctx.AckLSN,
+		}
+	}).(*stream)
+	stream.messageCH <- &Message{
+		message:  &format.Insert{TableName: "books"},
+		walStart: pq.LSN(11),
+		ackLSN:   pq.LSN(20),
+	}
+	close(stream.messageCH)
+
+	go stream.process(context.Background())
+
+	select {
+	case ctx := <-received:
+		if _, ok := ctx.Message.(*format.Insert); !ok {
+			t.Fatalf("message = %T, want *format.Insert", ctx.Message)
+		}
+		if ctx.WALStart != pq.LSN(11) {
+			t.Fatalf("WALStart = %s, want 0/B", ctx.WALStart)
+		}
+		if ctx.AckLSN != pq.LSN(20) {
+			t.Fatalf("AckLSN = %s, want 0/14", ctx.AckLSN)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("listener was not called")
+	}
+}
+
+func requireMessageCount(t *testing.T, ch <-chan *Message, want int) {
+	t.Helper()
+	if len(ch) != want {
+		t.Fatalf("message count = %d, want %d", len(ch), want)
+	}
+}
+
+func assertMessage[T any](t *testing.T, msg *Message, walStart pq.LSN, ackLSN pq.LSN) {
+	t.Helper()
+	if _, ok := msg.message.(T); !ok {
+		t.Fatalf("message = %T, want %T", msg.message, *new(T))
+	}
+	if msg.walStart != walStart {
+		t.Fatalf("walStart = %s, want %s", msg.walStart, walStart)
+	}
+	if msg.ackLSN != ackLSN {
+		t.Fatalf("ackLSN = %s, want %s", msg.ackLSN, ackLSN)
+	}
+}

--- a/pq/replication/stream_listener_test.go
+++ b/pq/replication/stream_listener_test.go
@@ -1,7 +1,9 @@
 package replication
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -9,6 +11,8 @@ import (
 	"github.com/Trendyol/go-pq-cdc/internal/metric"
 	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgproto3"
 )
 
 func TestDispatchDefaultKeepsRowOrientedListenerContract(t *testing.T) {
@@ -70,6 +74,90 @@ func TestDispatchCanEmitStreamCommitBoundary(t *testing.T) {
 	assertMessage[*format.StreamCommit](t, <-out, pq.LSN(33), pq.LSN(40))
 }
 
+func TestDispatchStreamAbortDiscardsBufferedRows(t *testing.T) {
+	cfg := config.Config{Listener: config.ListenerConfig{EmitTransactionBoundaries: true}}
+	stream := NewStream("", cfg, metric.NewMetric("test_slot"), func(*ListenerContext) {}).(*stream)
+	out := make(chan *Message, 8)
+	buf := &messageBuffer{outCh: out}
+	streamBuf := &streamTxBuffer{}
+
+	stream.dispatchMessage(&format.StreamStart{Xid: 7}, XLogData{WALStart: pq.LSN(30)}, buf, streamBuf)
+	stream.dispatchMessage(&format.Insert{TableName: "books"}, XLogData{WALStart: pq.LSN(31)}, buf, streamBuf)
+	stream.dispatchMessage(&format.StreamAbort{Xid: 7}, XLogData{WALStart: pq.LSN(32)}, buf, streamBuf)
+
+	requireMessageCount(t, out, 0)
+}
+
+func TestProcessDefaultAckAdvancesConfirmedLSN(t *testing.T) {
+	var ackErr error
+	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(ctx *ListenerContext) {
+		ackErr = ctx.Ack()
+	}).(*stream)
+	stream.conn = newWriteOnlyConn()
+	stream.UpdateXLogPos(pq.LSN(100))
+	stream.messageCH <- &Message{
+		message:  &format.Insert{TableName: "books"},
+		walStart: pq.LSN(11),
+		ackLSN:   pq.LSN(20),
+	}
+	close(stream.messageCH)
+
+	go stream.process(context.Background())
+	waitForProcessEnd(t, stream)
+
+	if ackErr != nil {
+		t.Fatalf("ack failed: %v", ackErr)
+	}
+	if stream.LoadConfirmedXLogPos() != pq.LSN(20) {
+		t.Fatalf("confirmed = %s, want 0/14", stream.LoadConfirmedXLogPos())
+	}
+}
+
+func TestProcessTransactionAwareAckOnlyAdvancesAtOrderedCommitBoundaries(t *testing.T) {
+	cfg := config.Config{Listener: config.ListenerConfig{EmitTransactionBoundaries: true}}
+	commitAcks := make([]func() error, 0, 2)
+	var nonCommitAckErr error
+	stream := NewStream("", cfg, metric.NewMetric("test_slot"), func(ctx *ListenerContext) {
+		switch ctx.Message.(type) {
+		case *format.Insert:
+			nonCommitAckErr = ctx.Ack()
+		case *format.Commit, *format.StreamCommit:
+			commitAcks = append(commitAcks, ctx.Ack)
+		}
+	}).(*stream)
+	stream.conn = newWriteOnlyConn()
+	stream.UpdateXLogPos(pq.LSN(100))
+	stream.messageCH <- &Message{message: &format.Insert{TableName: "books"}, walStart: pq.LSN(9), ackLSN: pq.LSN(10)}
+	stream.messageCH <- &Message{message: &format.Commit{TransactionEndLSN: pq.LSN(10)}, walStart: pq.LSN(10), ackLSN: pq.LSN(10)}
+	stream.messageCH <- &Message{message: &format.StreamCommit{Xid: 7, TransactionEndLSN: pq.LSN(20)}, walStart: pq.LSN(20), ackLSN: pq.LSN(20)}
+	close(stream.messageCH)
+
+	go stream.process(context.Background())
+	waitForProcessEnd(t, stream)
+
+	if nonCommitAckErr != nil {
+		t.Fatalf("non-commit ack failed: %v", nonCommitAckErr)
+	}
+	if stream.LoadConfirmedXLogPos() != 0 {
+		t.Fatalf("confirmed after non-commit ack = %s, want 0/0", stream.LoadConfirmedXLogPos())
+	}
+	if len(commitAcks) != 2 {
+		t.Fatalf("commit ack count = %d, want 2", len(commitAcks))
+	}
+	if err := commitAcks[1](); err != nil {
+		t.Fatalf("second commit ack failed: %v", err)
+	}
+	if stream.LoadConfirmedXLogPos() != 0 {
+		t.Fatalf("confirmed after second commit ack = %s, want 0/0", stream.LoadConfirmedXLogPos())
+	}
+	if err := commitAcks[0](); err != nil {
+		t.Fatalf("first commit ack failed: %v", err)
+	}
+	if stream.LoadConfirmedXLogPos() != pq.LSN(20) {
+		t.Fatalf("confirmed after first commit ack = %s, want 0/14", stream.LoadConfirmedXLogPos())
+	}
+}
+
 func TestProcessExposesWALMetadataToListener(t *testing.T) {
 	received := make(chan ListenerContext, 1)
 	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(ctx *ListenerContext) {
@@ -103,6 +191,34 @@ func TestProcessExposesWALMetadataToListener(t *testing.T) {
 		t.Fatal("listener was not called")
 	}
 }
+
+func waitForProcessEnd(t *testing.T, stream *stream) {
+	t.Helper()
+	select {
+	case <-stream.processEnd:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("processor did not finish")
+	}
+}
+
+type writeOnlyConn struct {
+	out *bytes.Buffer
+}
+
+func newWriteOnlyConn() *writeOnlyConn {
+	return &writeOnlyConn{out: &bytes.Buffer{}}
+}
+
+func (c *writeOnlyConn) Connect(context.Context) error { return nil }
+func (c *writeOnlyConn) IsClosed() bool                { return false }
+func (c *writeOnlyConn) Close(context.Context) error   { return nil }
+func (c *writeOnlyConn) ReceiveMessage(context.Context) (pgproto3.BackendMessage, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *writeOnlyConn) Frontend() *pgproto3.Frontend {
+	return pgproto3.NewFrontend(bytes.NewReader(nil), c.out)
+}
+func (c *writeOnlyConn) Exec(context.Context, string) *pgconn.MultiResultReader { return nil }
 
 func requireMessageCount(t *testing.T, ch <-chan *Message, want int) {
 	t.Helper()


### PR DESCRIPTION
## Summary

Some CDC consumers need to project a full committed PostgreSQL transaction atomically, persist the commit/checkpoint LSN, and only acknowledge replication after their projection is durable. The current row-oriented listener contract does not expose transaction boundaries or enough WAL metadata for that workflow.

This adds an opt-in transaction-aware listener mode:

- adds `config.Listener.EmitTransactionBoundaries`
- exposes `WALStart` and `AckLSN` on `replication.ListenerContext`
- emits `Begin`, `Commit`, and `StreamCommit` boundary messages only when the new option is enabled
- preserves the existing row-oriented default behavior

`docs/TRANSACTION_AWARE_LISTENER_API.md` includes the detailed API contract, semantics, compatibility notes, and covered behavior.

## Technical Explanation

The stream now tracks both the decoded message WAL start position and the LSN that `Ack()` should confirm. For row messages, `WALStart` remains the row message WAL position. For commit boundaries, `AckLSN` is the transaction end LSN so a transaction-aware listener can apply all changes durably before acknowledging the transaction checkpoint.

Regular transactions can emit `Begin -> rows -> Commit` when transaction boundaries are enabled. Streamed transactions continue buffering rows until `StreamCommit`; then buffered rows are emitted followed by the `StreamCommit` boundary. `StreamAbort` still discards buffered rows.

When `EmitTransactionBoundaries` is false, boundary messages are not emitted, so existing listeners that only handle row messages keep the current behavior.

## Tests

- `mise x go@1.23.2 -- go test ./...`
