### PR TITLE
chore: migrate golangci-lint v1 to v2 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,10 +33,6 @@ linters:
   settings:
     funlen:
       lines: 100
-    revive:
-      rules:
-        - name: exported
-          disabled: true
     gosec:
       excludes:
         - G115
@@ -46,7 +42,6 @@ linters:
     staticcheck:
       checks:
         - "all"
-        - "-S1009"
         - "-ST1000"
   exclusions:
     rules:
@@ -59,6 +54,12 @@ linters:
       - text: "Error return value of `.*Close` is not checked"
         linters:
           - errcheck
+      - text: "exported: exported .+ should have comment"
+        linters:
+          - revive
+      - text: "package-comments: should have a package comment"
+        linters:
+          - revive
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,13 @@
-linters-settings:
-  funlen:
-    lines: 100
+version: "2"
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dogsled
     - dupl
     - errcheck
     - errorlint
-    - exportloopref
     - funlen
     - gocheckcompilerdirectives
     - gochecknoinits
@@ -18,11 +15,8 @@ linters:
     - gocritic
     - gocyclo
     - godox
-    - gofmt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -31,17 +25,42 @@ linters:
     - nolintlint
     - revive
     - staticcheck
-    - stylecheck
     - testifylint
     - unconvert
     - unparam
     - unused
     - whitespace
+  settings:
+    funlen:
+      lines: 100
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+    gosec:
+      excludes:
+        - G115
+        - G117
+        - G104
+        - G304
+    staticcheck:
+      checks:
+        - "all"
+        - "-S1009"
+        - "-ST1000"
+  exclusions:
+    rules:
+      - path: (.+)_test.go
+        linters:
+          - funlen
+          - goconst
+          - dupl
+          - gosec
+      - text: "Error return value of `.*Close` is not checked"
+        linters:
+          - errcheck
 
-issues:
-  exclude-rules:
-    - path: (.+)_test.go
-      linters:
-        - funlen
-        - goconst
-        - dupl
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ init: init/lint
 
 .PHONY: init/lint  init/vulnCheck
 init/lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 	go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@v0.22.0
 
 .PHONY: init/vulnCheck
@@ -16,7 +16,7 @@ init/vulnCheck:
 audit: vendor
 	@echo 'Formatting code...'
 	fieldalignment -fix ./...
-	golangci-lint run -c .golangci.yml --timeout=5m -v --fix
+	golangci-lint run -c .golangci.yml -v --fix
 	@echo 'Vetting code...'
 	go vet ./...
 	@echo 'Vulnerability scanning...'
@@ -47,7 +47,7 @@ test/integration:
 lint: init/lint
 	@echo 'Formatting code...'
 	fieldalignment -fix ./...
-	golangci-lint run -c .golangci.yml --timeout=5m -v --fix
+	golangci-lint run -c .golangci.yml -v --fix
 
 .PHONY: build
 build/linux:

--- a/example/snapshot-initial-mode/main.go
+++ b/example/snapshot-initial-mode/main.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"context"
+	"log"
+	"log/slog"
+	"os"
+	"time"
+
 	cdc "github.com/Trendyol/go-pq-cdc"
 	"github.com/Trendyol/go-pq-cdc/config"
 	"github.com/Trendyol/go-pq-cdc/pq/message/format"
 	"github.com/Trendyol/go-pq-cdc/pq/publication"
 	"github.com/Trendyol/go-pq-cdc/pq/replication"
 	"github.com/Trendyol/go-pq-cdc/pq/slot"
-	"log"
-	"log/slog"
-	"os"
-	"time"
 )
 
 func main() {

--- a/example/snapshot-only-mode/main.go
+++ b/example/snapshot-only-mode/main.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"context"
+	"log"
+	"log/slog"
+	"os"
+	"time"
+
 	cdc "github.com/Trendyol/go-pq-cdc"
 	"github.com/Trendyol/go-pq-cdc/config"
 	"github.com/Trendyol/go-pq-cdc/pq/message/format"
 	"github.com/Trendyol/go-pq-cdc/pq/publication"
 	"github.com/Trendyol/go-pq-cdc/pq/replication"
-	"log"
-	"log/slog"
-	"os"
-	"time"
 )
 
 func main() {

--- a/example/snapshot-with-query-condition/main.go
+++ b/example/snapshot-with-query-condition/main.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"context"
+	"log"
+	"log/slog"
+	"os"
+	"time"
+
 	cdc "github.com/Trendyol/go-pq-cdc"
 	"github.com/Trendyol/go-pq-cdc/config"
 	"github.com/Trendyol/go-pq-cdc/pq/message/format"
 	"github.com/Trendyol/go-pq-cdc/pq/publication"
 	"github.com/Trendyol/go-pq-cdc/pq/replication"
 	"github.com/Trendyol/go-pq-cdc/pq/slot"
-	"log"
-	"log/slog"
-	"os"
-	"time"
 )
 
 func main() {
@@ -111,4 +112,3 @@ func handleSnapshot(s *format.Snapshot) {
 			s.ServerTime.Format("15:04:05"))
 	}
 }
-

--- a/pq/message/format/begin.go
+++ b/pq/message/format/begin.go
@@ -2,9 +2,10 @@ package format
 
 import (
 	"encoding/binary"
+	"time"
+
 	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/go-playground/errors"
-	"time"
 )
 
 type Begin struct {

--- a/pq/message/format/commit.go
+++ b/pq/message/format/commit.go
@@ -2,9 +2,10 @@ package format
 
 import (
 	"encoding/binary"
+	"time"
+
 	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/go-playground/errors"
-	"time"
 )
 
 type Commit struct {

--- a/pq/message/format/insert_test.go
+++ b/pq/message/format/insert_test.go
@@ -59,5 +59,5 @@ func TestInsert_New(t *testing.T) {
 		MessageTime:    now,
 	}
 
-	assert.EqualValues(t, expected, msg)
+	assert.Equal(t, expected, msg)
 }

--- a/pq/snapshot/coordinator_test.go
+++ b/pq/snapshot/coordinator_test.go
@@ -12,7 +12,7 @@ func ptrInt64(v int64) *int64 { return &v }
 
 func TestAndCondition(t *testing.T) {
 	t.Run("both empty returns empty", func(t *testing.T) {
-		assert.Equal(t, "", andCondition("", ""))
+		assert.Empty(t, andCondition("", ""))
 	})
 	t.Run("only existing returns existing", func(t *testing.T) {
 		assert.Equal(t, "a = 1", andCondition("a = 1", ""))
@@ -34,7 +34,7 @@ func TestGetQueryCondition(t *testing.T) {
 		s := newSnapshotter(config.SnapshotConfig{}, publication.Tables{
 			{Name: "users", Schema: "public"},
 		})
-		assert.Equal(t, "", s.getQueryCondition("public", "users"))
+		assert.Empty(t, s.getQueryCondition("public", "users"))
 	})
 
 	t.Run("returns global condition when no per-table override", func(t *testing.T) {

--- a/pq/snapshot/worker.go
+++ b/pq/snapshot/worker.go
@@ -538,12 +538,12 @@ func (s *Snapshotter) parseClaimedChunk(row [][]byte, slotName, instanceID strin
 	chunk.BlockEnd = blockEnd
 
 	// Parse is_last_chunk (boolean)
-	if row[10] != nil && len(row[10]) > 0 {
+	if len(row[10]) > 0 {
 		chunk.IsLastChunk = string(row[10]) == "t" || string(row[10]) == "true"
 	}
 
 	// Parse partition strategy
-	if row[11] != nil && len(row[11]) > 0 {
+	if len(row[11]) > 0 {
 		chunk.PartitionStrategy = PartitionStrategy(string(row[11]))
 	} else {
 		chunk.PartitionStrategy = PartitionStrategyOffset


### PR DESCRIPTION
## Summary                                   
  - Migrate golangci-lint from v1.59.1 to v2.11.4 as a prerequisite for bumping Go to 1.24                                                                                                                                        
  - golangci-lint v1 does not support Go 1.24; v2 is required for compatibility                                                                                                                                                   
  - Update `.golangci.yml` to v2 format: `disable-all` → `default: none`, `issues.exclude-rules` → `linters.exclusions.rules`, move `gofmt`/`goimports` to `formatters` section                                                   
  - Remove deprecated linters (`exportloopref`, `gosimple`, `stylecheck` — merged into `staticcheck` in v2)                                                                                                                       
  - Fix S1009: remove redundant nil check before `len()` in snapshot worker                                                                                                                                                       
  - Auto-fixes applied by `--fix`: import ordering in examples, test assertion improvements                                                                                                                                       
                                                                                                                                                                                                                                  
  ### Exclusions                                               
                                               
  golangci-lint v2 bundles newer linter versions that surface findings not present in v1. The following are suppressed as false positives or deferred for a follow-up PR:                                                         
   
  | Rule | Linter | Reason |                                                                                                                                                                                                      
  |------|--------|--------|                                   
  | G115 | gosec | Integer overflow on `uint8`/`uint16`/`uint32` casts in wire protocol decoding — values are bounded by PostgreSQL pgoutput binary format, overflow is not possible |
  | G117 | gosec | Flags hardcoded credentials in test fixtures and config field names — false positive, no actual secrets |                                                                                                      
  | G104 | gosec | Unhandled errors on deferred `Close()` calls — standard Go pattern for cleanup, also covered by errcheck exclusion below |                                                                                     
  | G304 | gosec | File path inclusion in `config.ReadConfigYAML`/`ReadConfigJSON` — path comes from caller, not user input |                                                                                                     
  | errcheck `Close` | errcheck | `Error return value of .*Close is not checked` — deferred Close() on readers/connections where error handling is not actionable |                                                               
  | `exported` | revive | Missing doc comments on exported symbols — valid but ~50+ symbols across 15+ files. Deferred to a dedicated follow-up PR to keep this migration focused |                                               
  | `package-comments` | revive | Missing package-level doc comments — same as above, deferred to follow-up |                                                                                                                     
  | ST1000 | staticcheck | Same check as `package-comments` but from staticcheck — suppressed for consistency |                                                                                                                   
                                                                                                                                                                                                                                  
  ## Tests                                                                                                                                                                                                                        
  - [x] `golangci-lint run ./...` — 0 issues                                                                                                                                                                                      
  - [x] `go test ./...` — all unit tests pass                  
  - [x] No behavioral code changes (lint config + one nil-check removal) 