### PR TITLE
fix: enable graceful termination during slog capturing

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -616,6 +616,9 @@ func (c *connector) CaptureSlot(ctx context.Context) {
 	for range ticker.C {
 		info, err := c.slot.Info(ctx)
 		if err != nil {
+			if goerrors.Is(err, slot.ErrorSlotClosed) {
+				return
+			}
 			logger.Warn("slot info failed on capture slot", "error", err)
 			continue
 		}


### PR DESCRIPTION
## Reason

Currently, `CaptureSlot()` can hang indefinitely after the slot is closed. This PR changes `CaptureSlot()` so that it returns when the slot has been closed. This allows callers to implement graceful termination by closing the slot when the context is cancelled:

```go
	ctx, cancel := context.WithCancel(ctx)
	defer cancel()
	go func() {
		<-ctx.Done()
		connector.Close()
	}()
	// blocks
	connector.Start(ctx)
```

Note a closed slot will never be opened again:
https://github.com/Trendyol/go-pq-cdc/blob/ebadfbc11b43276556ce8ea8cb2a42920c531839/pq/slot/slot.go#L116-L125