### PR TITLE
fix: fail startup when heartbeat table is missing from publication (#136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,25 @@ heartbeat:
 
 You can run [Simple With Heartbeat](./example/simple-with-heartbeat) example.
 
+#### Upgrade: heartbeat table must be in publication
+
+If you use heartbeat with a **selective publication** (`publication.tables` is non-empty and the publication is not `FOR ALL TABLES`), the connector now **fails at startup** when the heartbeat table is missing from `publication.tables`.
+
+Previously, this misconfiguration could still start successfully, but heartbeat writes would not reach the replication slot and WAL retention would not improve.
+
+Before upgrading, add the heartbeat table to your publication config (or switch to a `FOR ALL TABLES` publication):
+
+```yaml
+publication:
+  name: cdc_publication
+  createIfNotExists: true
+  tables:
+    - name: users
+      schema: public
+    - name: my_heartbeat
+      schema: public
+```
+
 #### Replica Identity Requirement
 
 For this TOAST reconstruction to work, PostgreSQL must send the old tuple.
@@ -445,5 +464,5 @@ Import the grafana dashboard [json file](./grafana/dashboard.json).
 ### Breaking Changes
 
 | Date taking effect | Version | Change | How to check |
-|--------------------|---------|--------|--------------| 
-| -                  | -       | -      | -            |
+|--------------------|---------|--------|--------------|
+| Next release       | TBD     | Startup fails when heartbeat is enabled but the heartbeat table is missing from a selective publication. | Ensure `publication.tables` includes your heartbeat table, or use a `FOR ALL TABLES` publication. See [Upgrade: heartbeat table must be in publication](#upgrade-heartbeat-table-must-be-in-publication). |

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ databases on the same instance are generating heavy write load.
 > The heartbeat table must satisfy **both** conditions below — otherwise the auto-`UPDATE`s commit successfully but the slot never decodes them, `confirmed_flush_lsn` stays frozen, and WAL keeps growing as if heartbeat were disabled:
 >
 > 1. The heartbeat table is listed in `publication.tables`. If it is not part of the publication the change is filtered out before reaching the slot.
+>    The connector validates this at startup for selective publications and returns an error if the heartbeat table is missing.
 > 2. The heartbeat table has a `REPLICA IDENTITY` that allows the auto-`UPDATE` to be decoded — `DEFAULT` (the auto-created table already has a primary key, so this works out of the box) or `FULL`. `REPLICA IDENTITY NOTHING` will silently break WAL advancement because the `UPDATE` cannot be decoded by `pgoutput`.
 >
 > Use a dedicated heartbeat table — never reuse a business table.

--- a/config/config.go
+++ b/config/config.go
@@ -203,6 +203,29 @@ func (c *Config) validateSnapshotSubset(pubTables publication.Tables) (publicati
 	return validatedTables, nil
 }
 
+func (c *Config) ValidateHeartbeatInPublication(pubInfo *publication.Config) error {
+	if !c.IsHeartbeatEnabled() || pubInfo == nil {
+		return nil
+	}
+	if pubInfo.AllTables {
+		return nil
+	}
+
+	schema := c.Heartbeat.Table.Schema
+	if schema == "" {
+		schema = defaultSchema
+	}
+	name := c.Heartbeat.Table.Name
+	if pubInfo.Tables.Contains(schema, name) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"heartbeat table %s.%s is not included in publication %q; add it to publication.tables so heartbeat changes reach the replication slot",
+		schema, name, pubInfo.Name,
+	)
+}
+
 func (c *Config) Validate() error {
 	var err error
 	if isEmpty(c.Host) {
@@ -240,6 +263,14 @@ func (c *Config) Validate() error {
 	if c.Heartbeat.Table.Name != "" {
 		if c.Heartbeat.Interval <= 0 {
 			err = errors.Join(err, errors.New("heartbeat.interval must be greater than 0 when heartbeat table is configured"))
+		}
+		if !c.IsSnapshotOnlyMode() && len(c.Publication.Tables) > 0 {
+			if hErr := c.ValidateHeartbeatInPublication(&publication.Config{
+				Name:   c.Publication.Name,
+				Tables: c.Publication.Tables,
+			}); hErr != nil {
+				err = errors.Join(err, hErr)
+			}
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -207,7 +207,8 @@ func (c *Config) ValidateHeartbeatInPublication(pubInfo *publication.Config) err
 	if !c.IsHeartbeatEnabled() || pubInfo == nil {
 		return nil
 	}
-	if pubInfo.AllTables {
+
+	if c.Publication.AllTables || pubInfo.AllTables {
 		return nil
 	}
 
@@ -216,14 +217,14 @@ func (c *Config) ValidateHeartbeatInPublication(pubInfo *publication.Config) err
 		schema = defaultSchema
 	}
 	name := c.Heartbeat.Table.Name
-	if pubInfo.Tables.Contains(schema, name) {
-		return nil
+	if !pubInfo.Tables.Contains(schema, name) {
+		return fmt.Errorf(
+			"heartbeat table %s.%s is not included in publication %q; add it to publication.tables so heartbeat changes reach the replication slot",
+			schema, name, pubInfo.Name,
+		)
 	}
 
-	return fmt.Errorf(
-		"heartbeat table %s.%s is not included in publication %q; add it to publication.tables so heartbeat changes reach the replication slot",
-		schema, name, pubInfo.Name,
-	)
+	return nil
 }
 
 func (c *Config) Validate() error {
@@ -259,12 +260,11 @@ func (c *Config) Validate() error {
 		err = errors.Join(err, cErr)
 	}
 
-	// Heartbeat validation
-	if c.Heartbeat.Table.Name != "" {
+	if c.IsHeartbeatEnabled() {
 		if c.Heartbeat.Interval <= 0 {
 			err = errors.Join(err, errors.New("heartbeat.interval must be greater than 0 when heartbeat table is configured"))
 		}
-		if !c.IsSnapshotOnlyMode() && len(c.Publication.Tables) > 0 {
+		if !c.IsSnapshotOnlyMode() && !c.Publication.AllTables && len(c.Publication.Tables) > 0 {
 			if hErr := c.ValidateHeartbeatInPublication(&publication.Config{
 				Name:   c.Publication.Name,
 				Tables: c.Publication.Tables,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -553,7 +553,6 @@ func TestSnapshotConfigValidateQueryCondition(t *testing.T) {
 	})
 }
 
-
 func TestValidateHeartbeatInPublication(t *testing.T) {
 	validBase := func() Config {
 		return Config{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Trendyol/go-pq-cdc/pq/publication"
+	"github.com/Trendyol/go-pq-cdc/pq/slot"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -549,5 +550,90 @@ func TestSnapshotConfigValidateQueryCondition(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "snapshot.tables")
 		assert.Contains(t, err.Error(), `"/*"`)
+	})
+}
+
+
+func TestValidateHeartbeatInPublication(t *testing.T) {
+	validBase := func() Config {
+		return Config{
+			Host:     "localhost",
+			Username: "user",
+			Password: "pass",
+			Database: "db",
+			Slot: slot.Config{
+				Name:                        "slot",
+				CreateIfNotExists:           true,
+				SlotActivityCheckerInterval: 1000,
+			},
+			Publication: publication.Config{
+				Name:              "pub",
+				CreateIfNotExists: true,
+				Operations:        publication.Operations{publication.OperationInsert},
+			},
+		}
+	}
+
+	t.Run("passes when heartbeat table is in publication.tables", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Heartbeat = HeartbeatConfig{
+			Table:    publication.Table{Name: "heartbeat_events", Schema: "public", ReplicaIdentity: publication.ReplicaIdentityFull},
+			Interval: 100 * time.Millisecond,
+		}
+		cfg.Publication.Tables = publication.Tables{
+			{Name: "users", Schema: "public", ReplicaIdentity: publication.ReplicaIdentityFull},
+			{Name: "heartbeat_events", Schema: "public", ReplicaIdentity: publication.ReplicaIdentityFull},
+		}
+
+		err := cfg.Validate()
+		require.NoError(t, err)
+	})
+
+	t.Run("fails when heartbeat table is missing from publication.tables", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Heartbeat = HeartbeatConfig{
+			Table:    publication.Table{Name: "heartbeat_events", Schema: "public", ReplicaIdentity: publication.ReplicaIdentityFull},
+			Interval: 100 * time.Millisecond,
+		}
+		cfg.Publication.Tables = publication.Tables{
+			{Name: "users", Schema: "public", ReplicaIdentity: publication.ReplicaIdentityFull},
+		}
+
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "heartbeat table public.heartbeat_events is not included in publication")
+	})
+
+	t.Run("skips check for puballtables publications", func(t *testing.T) {
+		cfg := Config{
+			Heartbeat: HeartbeatConfig{
+				Table: publication.Table{Name: "heartbeat_events", Schema: "public"},
+			},
+		}
+		pubInfo := &publication.Config{
+			Name:      "pub",
+			AllTables: true,
+			Tables:    publication.Tables{{Name: "users", Schema: "public"}},
+		}
+
+		require.NoError(t, cfg.ValidateHeartbeatInPublication(pubInfo))
+	})
+
+	t.Run("runtime check uses actual publication info tables", func(t *testing.T) {
+		cfg := Config{
+			Heartbeat: HeartbeatConfig{
+				Table: publication.Table{Name: "heartbeat_events", Schema: "public"},
+			},
+		}
+		pubInfo := &publication.Config{
+			Name: "pub",
+			Tables: publication.Tables{
+				{Name: "users", Schema: "public"},
+			},
+		}
+
+		err := cfg.ValidateHeartbeatInPublication(pubInfo)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `publication "pub"`)
 	})
 }

--- a/connector.go
+++ b/connector.go
@@ -109,6 +109,10 @@ func NewConnector(ctx context.Context, cfg config.Config, listenerFunc replicati
 	if err != nil {
 		return nil, err
 	}
+	if err := cfg.ValidateHeartbeatInPublication(publicationInfo); err != nil {
+		conn.Close(ctx)
+		return nil, err
+	}
 	logger.Info("publication", "info", publicationInfo)
 
 	// Close the setup connection - we don't need it anymore

--- a/connector.go
+++ b/connector.go
@@ -94,28 +94,11 @@ func NewConnector(ctx context.Context, cfg config.Config, listenerFunc replicati
 		return nil, err
 	}
 
-	// Create heartbeat table BEFORE publication setup (if configured)
-	// This ensures the table exists when publication tries to set replica identity
-	var hb *heartbeat.Heartbeat
-	if cfg.IsHeartbeatEnabled() {
-		hb = heartbeat.New(cfg.DSN(), cfg.Heartbeat)
-		if err := hb.EnsureTable(ctx, conn); err != nil {
-			conn.Close(ctx)
-			return nil, errors.Wrap(err, "create heartbeat table")
-		}
-	}
-
-	publicationInfo, err := initializePublication(ctx, cfg, conn)
+	hb, publicationInfo, err := setupHeartbeatAndPublication(ctx, cfg, conn)
 	if err != nil {
-		return nil, err
-	}
-	if err := cfg.ValidateHeartbeatInPublication(publicationInfo); err != nil {
 		conn.Close(ctx)
 		return nil, err
 	}
-	logger.Info("publication", "info", publicationInfo)
-
-	// Close the setup connection - we don't need it anymore
 	conn.Close(ctx)
 
 	m := metric.NewMetric(cfg.Slot.Name)
@@ -137,16 +120,9 @@ func NewConnector(ctx context.Context, cfg config.Config, listenerFunc replicati
 
 	prometheusRegistry := metric.NewRegistry(m)
 
-	var tdb *timescaledb.TimescaleDB
-	if cfg.ExtensionSupport.EnableTimeScaleDB {
-		tdb, err = timescaledb.NewTimescaleDB(ctx, cfg.DSN())
-		if err != nil {
-			return nil, err
-		}
-		_, err = tdb.FindHyperTables(ctx)
-		if err != nil {
-			return nil, err
-		}
+	tdb, err := initializeTimescaleDB(ctx, cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	return &connector{
@@ -196,6 +172,40 @@ func newSnapshotOnlyConnector(ctx context.Context, cfg config.Config, listenerFu
 		readyCh:            make(chan struct{}, 1),
 		// CDC components left nil: system, stream, slot
 	}, nil
+}
+
+func setupHeartbeatAndPublication(ctx context.Context, cfg config.Config, conn pq.Connection) (*heartbeat.Heartbeat, *publication.Config, error) {
+	var hb *heartbeat.Heartbeat
+	if cfg.IsHeartbeatEnabled() {
+		hb = heartbeat.New(cfg.DSN(), cfg.Heartbeat)
+		if err := hb.EnsureTable(ctx, conn); err != nil {
+			return nil, nil, errors.Wrap(err, "create heartbeat table")
+		}
+	}
+
+	publicationInfo, err := initializePublication(ctx, cfg, conn)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cfg.ValidateHeartbeatInPublication(publicationInfo); err != nil {
+		return nil, nil, err
+	}
+	logger.Info("publication", "info", publicationInfo)
+	return hb, publicationInfo, nil
+}
+
+func initializeTimescaleDB(ctx context.Context, cfg config.Config) (*timescaledb.TimescaleDB, error) {
+	if !cfg.ExtensionSupport.EnableTimeScaleDB {
+		return nil, nil
+	}
+	tdb, err := timescaledb.NewTimescaleDB(ctx, cfg.DSN())
+	if err != nil {
+		return nil, err
+	}
+	if _, err = tdb.FindHyperTables(ctx); err != nil {
+		return nil, err
+	}
+	return tdb, nil
 }
 
 // initializePublication sets up and creates the publication

--- a/integration_test/heartbeat_test.go
+++ b/integration_test/heartbeat_test.go
@@ -23,6 +23,7 @@ func TestHeartbeatAdvancesLSN(t *testing.T) {
 	// Use base config but customize slot / publication / heartbeat for this test
 	cdcCfg := Config
 	cdcCfg.Slot.Name = "slot_test_heartbeat_lsn"
+	cdcCfg.Publication.Tables = append(publication.Tables(nil), Config.Publication.Tables...)
 
 	forEachProtoVersion(t, cdcCfg, func(t *testing.T, cdcCfg config.Config) {
 		postgresConn, err := newPostgresConn()
@@ -116,6 +117,9 @@ func TestHeartbeatMissingFromPublicationFails(t *testing.T) {
 	ctx := context.Background()
 	cdcCfg := Config
 	cdcCfg.Slot.Name = "slot_test_heartbeat_missing_pub"
+	cdcCfg.Publication.Tables = publication.Tables{
+		{Name: "books", ReplicaIdentity: publication.ReplicaIdentityFull},
+	}
 
 	forEachProtoVersion(t, cdcCfg, func(t *testing.T, cdcCfg config.Config) {
 		postgresConn, err := newPostgresConn()

--- a/integration_test/heartbeat_test.go
+++ b/integration_test/heartbeat_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Trendyol/go-pq-cdc/pq/publication"
 	"github.com/Trendyol/go-pq-cdc/pq/replication"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHeartbeatAdvancesLSN(t *testing.T) {
@@ -105,6 +106,46 @@ func TestHeartbeatAdvancesLSN(t *testing.T) {
 		// it should also advance when only heartbeat is producing changes.
 		assert.NotEmpty(t, initialRestart)
 		assert.NotEmpty(t, finalRestart)
+	})
+}
+
+
+func TestHeartbeatMissingFromPublicationFails(t *testing.T) {
+	t.Helper()
+
+	ctx := context.Background()
+	cdcCfg := Config
+	cdcCfg.Slot.Name = "slot_test_heartbeat_missing_pub"
+
+	forEachProtoVersion(t, cdcCfg, func(t *testing.T, cdcCfg config.Config) {
+		postgresConn, err := newPostgresConn()
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		if !assert.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg)) {
+			t.FailNow()
+		}
+
+		// Heartbeat enabled but heartbeat table intentionally omitted from publication.tables
+		cdcCfg.Heartbeat = config.HeartbeatConfig{
+			Table: publication.Table{
+				Name:   "heartbeat_events",
+				Schema: "public",
+			},
+			Interval: 2 * time.Second,
+		}
+
+		t.Cleanup(func() {
+			assert.NoError(t, RestoreDB(ctx))
+			assert.NoError(t, postgresConn.Close(ctx))
+		})
+
+		_, err = cdc.NewConnector(ctx, cdcCfg, func(ctx *replication.ListenerContext) {
+			_ = ctx.Ack()
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "heartbeat table public.heartbeat_events is not included in publication")
 	})
 }
 

--- a/pq/publication/config.go
+++ b/pq/publication/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Operations        Operations `json:"operations" yaml:"operations"`
 	Tables            Tables     `json:"tables" yaml:"tables"`
 	CreateIfNotExists bool       `json:"createIfNotExists" yaml:"createIfNotExists"`
+	AllTables         bool       `json:"-" yaml:"-"`
 }
 
 func (c Config) Validate() error {

--- a/pq/publication/publication.go
+++ b/pq/publication/publication.go
@@ -97,6 +97,8 @@ func decodePublicationInfoResult(result *pgconn.Result) (*Config, error) {
 		switch fd.Name {
 		case "pubname":
 			publicationConfig.Name = v.(string)
+		case "puballtables":
+			publicationConfig.AllTables = v.(bool)
 		case "pubinsert":
 			if v.(bool) {
 				publicationConfig.Operations = append(publicationConfig.Operations, "INSERT")

--- a/pq/publication/table.go
+++ b/pq/publication/table.go
@@ -77,6 +77,24 @@ func (tc Table) Validate() error {
 
 type Tables []Table
 
+const defaultTableSchema = "public"
+
+func (ts Tables) Contains(schema, name string) bool {
+	if schema == "" {
+		schema = defaultTableSchema
+	}
+	for _, t := range ts {
+		tblSchema := t.Schema
+		if tblSchema == "" {
+			tblSchema = defaultTableSchema
+		}
+		if tblSchema == schema && t.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func (ts Tables) Validate() error {
 	if len(ts) == 0 {
 		return errors.New("at least one table must be defined")

--- a/pq/publication/table_test.go
+++ b/pq/publication/table_test.go
@@ -99,3 +99,15 @@ func TestTablesDiffReplicaIdentityIndex(t *testing.T) {
 		assert.Empty(t, diff[0].ReplicaIdentityIndex)
 	})
 }
+
+func TestTablesContains(t *testing.T) {
+	tables := Tables{
+		{Name: "users", Schema: "public"},
+		{Name: "events", Schema: "tenant_a"},
+	}
+
+	assert.True(t, tables.Contains("public", "users"))
+	assert.True(t, tables.Contains("", "users"))
+	assert.True(t, tables.Contains("tenant_a", "events"))
+	assert.False(t, tables.Contains("public", "orders"))
+}


### PR DESCRIPTION
Fixes #136

Fail at startup when heartbeat is enabled but the heartbeat table is not included in a selective publication