### PR TITLE
fix(replication): serialize connection access to prevent corrupted-connection panic

### DIFF
--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -70,6 +70,18 @@ type stream struct {
 	sinkStarted         atomic.Bool
 	processStarted      atomic.Bool
 	messageCloseOnce    sync.Once
+	// connMu serializes every use of conn while streaming. The sink goroutine
+	// reads with ReceiveMessage, which toggles the connection's socket deadline
+	// via pgconn's context watcher (SetDeadline(now) to interrupt the read, then
+	// SetDeadline(zero) to clear it). Standby status updates are written straight
+	// to the frontend, bypassing pgconn's own lock, and may be sent from the
+	// process goroutine or — when the consumer defers Ack — from a third
+	// goroutine entirely. A status-update write that lands in ReceiveMessage's
+	// deadline-cancel window inherits the past deadline and fails with an i/o
+	// timeout, corrupting the connection and panicking the sink. Holding connMu
+	// across the read and every write makes them mutually exclusive so that can't
+	// happen. connMu is always acquired before mu, never the reverse.
+	connMu sync.Mutex
 }
 
 func NewStream(dsn string, cfg config.Config, m metric.Metric, listenerFunc ListenerFunc) Streamer {
@@ -290,7 +302,14 @@ func (s *stream) sink(ctx context.Context) {
 func (s *stream) sinkLoop(ctx context.Context, buf *messageBuffer, streamBuf *streamTxBuffer) (corrupted bool) {
 	for {
 		msgCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(300*time.Millisecond))
+		// Hold connMu only for the read itself. ReceiveMessage's deferred Unwatch
+		// (which clears the socket deadline) has run by the time it returns, so the
+		// deadline-toggle window is fully contained here; releasing before the
+		// channel sends in handleXLogData keeps acks from blocking the sink and
+		// vice versa.
+		s.connMu.Lock()
 		rawMsg, err := s.conn.ReceiveMessage(msgCtx)
+		s.connMu.Unlock()
 		cancel()
 
 		if err != nil {
@@ -300,7 +319,7 @@ func (s *stream) sinkLoop(ctx context.Context, buf *messageBuffer, streamBuf *st
 			}
 			if pgconn.Timeout(err) {
 				if s.LoadXLogPos() > 0 {
-					if err = SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos())); err != nil {
+					if err = s.sendStandbyStatusUpdate(ctx); err != nil {
 						logger.Error("send stand by status update", "error", err)
 						return true
 					}
@@ -363,7 +382,7 @@ func (s *stream) handleKeepalive(ctx context.Context, data []byte) error {
 	}
 
 	if pkm.ReplyRequested {
-		if err = SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos())); err != nil {
+		if err = s.sendStandbyStatusUpdate(ctx); err != nil {
 			logger.Error("standby status update", "error", err)
 			return err
 		}
@@ -485,7 +504,7 @@ func (s *stream) process(ctx context.Context) {
 				pos := pq.LSN(msg.walStart)
 				s.UpdateConfirmedXLogPos(pos)
 				logger.Debug("send stand by status update", "xLogPos", s.LoadConfirmedXLogPos().String())
-				return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos()))
+				return s.sendStandbyStatusUpdate(ctx)
 			}
 
 			if s.isHeartbeatMessage(msg.message) {
@@ -683,6 +702,17 @@ func (s *stream) fetchSnapshotLSN(ctx context.Context) (pq.LSN, error) {
 
 	logger.Info("fetched snapshot LSN from database", "slotName", s.config.Slot.Name, "snapshotLSN", snapshotLSN.String())
 	return snapshotLSN, nil
+}
+
+// sendStandbyStatusUpdate writes a standby status update under connMu so it can
+// never overlap the sink loop's ReceiveMessage, which toggles the connection's
+// socket deadline. Every status-update write — idle keepalive, reply-on-request,
+// and consumer Ack — must go through here rather than calling
+// SendStandbyStatusUpdate directly. See the connMu field comment.
+func (s *stream) sendStandbyStatusUpdate(ctx context.Context) error {
+	s.connMu.Lock()
+	defer s.connMu.Unlock()
+	return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos()))
 }
 
 func SendStandbyStatusUpdate(_ context.Context, conn pq.Connection, walReceivedPosition, walFlushedPosition uint64) error {

--- a/pq/replication/stream_connmu_test.go
+++ b/pq/replication/stream_connmu_test.go
@@ -1,0 +1,120 @@
+package replication
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/internal/metric"
+	"github.com/Trendyol/go-pq-cdc/logger"
+	"github.com/Trendyol/go-pq-cdc/pq/message"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgproto3"
+)
+
+// serializeProbeConn is a pq.Connection fake that flags any overlap between a
+// ReceiveMessage (the sink's read) and a frontend write (a standby status
+// update). The bug this guards against: the read path toggles the socket
+// deadline via pgconn's context watcher while an off-goroutine ack writes to the
+// same connection, so the write inherits a past deadline and fails with an i/o
+// timeout, corrupting the stream and panicking the sink. connMu must keep the
+// read and every write mutually exclusive.
+type serializeProbeConn struct {
+	fe        *pgproto3.Frontend
+	keepalive []byte
+
+	active   int32 // in-flight read-or-write ops; must never exceed 1
+	overlaps int32
+	stop     atomic.Bool
+}
+
+// mark records the start of a read or write, flags it if another op is already
+// in flight, holds briefly to widen the overlap window, and returns a closure
+// that records the end.
+func (c *serializeProbeConn) mark() func() {
+	if atomic.AddInt32(&c.active, 1) != 1 {
+		atomic.AddInt32(&c.overlaps, 1)
+	}
+	time.Sleep(20 * time.Microsecond)
+	return func() { atomic.AddInt32(&c.active, -1) }
+}
+
+func (c *serializeProbeConn) Connect(context.Context) error                          { return nil }
+func (c *serializeProbeConn) IsClosed() bool                                         { return false }
+func (c *serializeProbeConn) Close(context.Context) error                            { return nil }
+func (c *serializeProbeConn) Exec(context.Context, string) *pgconn.MultiResultReader { return nil }
+func (c *serializeProbeConn) Frontend() *pgproto3.Frontend                           { return c.fe }
+
+func (c *serializeProbeConn) ReceiveMessage(context.Context) (pgproto3.BackendMessage, error) {
+	if c.stop.Load() {
+		return nil, errors.New("stopped")
+	}
+	defer c.mark()()
+	// A keepalive with ReplyRequested=0 keeps the sink looping without making it
+	// send a status update itself, so every write the probe sees comes from the
+	// concurrent ackers.
+	return &pgproto3.CopyData{Data: c.keepalive}, nil
+}
+
+// serializeProbeWriter is the io.Writer behind the fake's frontend; every
+// standby status update is written here.
+type serializeProbeWriter struct{ c *serializeProbeConn }
+
+func (w serializeProbeWriter) Write(p []byte) (int, error) {
+	defer w.c.mark()()
+	return len(p), nil
+}
+
+// TestStandbyUpdateIsSerializedWithReceive runs the real sink loop against a fake
+// connection while four goroutines ack off the sink goroutine — the way the
+// consumer's coalescer does. With connMu, the read and the writes never overlap.
+func TestStandbyUpdateIsSerializedWithReceive(t *testing.T) {
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+
+	c := &serializeProbeConn{keepalive: make([]byte, 18)}
+	c.keepalive[0] = message.PrimaryKeepaliveMessageByteID // 'k'; 17 zero body bytes => ReplyRequested=false
+	c.fe = pgproto3.NewFrontend(strings.NewReader(""), serializeProbeWriter{c})
+
+	s := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(*ListenerContext) {}).(*stream)
+	s.conn = c
+	s.lastXLogPos = 1 // so sendStandbyStatusUpdate writes a real payload
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.sinkLoop(ctx, &messageBuffer{outCh: make(chan *Message, 4096)}, &streamTxBuffer{})
+	}()
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ctx.Err() == nil {
+				_ = s.sendStandbyStatusUpdate(ctx)
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Stop cleanly: closed=true makes the sink treat the next read error as a
+	// normal stop (returns false, no panic). Set closed before stop so it's
+	// observed by the time the read errors; cancel unblocks the ackers.
+	s.closed.Store(true)
+	c.stop.Store(true)
+	cancel()
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&c.overlaps); got != 0 {
+		t.Fatalf("read and standby-update write overlapped %d time(s); connMu did not serialize connection access", got)
+	}
+}


### PR DESCRIPTION
This issue happend to me when I developed a process that accumulates updates and send them in one batch every few miliseconds what happens is that the stream panics with `panic: corrupted connection` whenever a standby
status update write to Postgres fails with an `i/o timeout`:

    ... write tcp <pod>->...:5432: i/o timeout
    postgres connection closed
    panic: corrupted connection
        pq/replication.(*stream).sink(...) stream.go:282

## Root cause

A 34-byte status-update write cannot time out from real network slowness
the `i/o timeout` is a socket deadline that was already in the past when
the write ran. That deadline is set and then concurrently tripped by the
read path.

The stream uses one replication connection from two goroutines at once:

- `sink` reads via `conn.ReceiveMessage(msgCtx)`, where `msgCtx` carries a
  300ms deadline (refreshed every loop iteration). When that deadline
  fires, pgconn's context watcher interrupts the blocked read by calling
  `SetDeadline(time.Now())` on the underlying `net.Conn`, then clears it
  with `SetDeadline(time.Time{})` once `ReceiveMessage` unwinds.

- standby status updates are written with `SendStandbyStatusUpdate`, which
  goes straight to `conn.Frontend().SendUnbufferedEncodedCopyData(...)`
  bypassing pgconn's own connection lock. These writes come from the
  `process` goroutine and, when a consumer defers `Ack` to its own
  goroutine, from a third goroutine entirely.

Nothing serialized the read against the writes. A status-update write that
lands in the `SetDeadline(now)` → `SetDeadline(zero)` window inherits the
past deadline, fails with `i/o timeout`, and leaves the wire protocol in an
inconsistent state. `sinkLoop` then reports the connection corrupted and
`sink` panics by design.

## Why it shows up under low traffic / with a deferred Ack

The collision window is normally tiny, so the race is rare:

- Under load, `ReceiveMessage` returns real data well before 300ms, so the
  deadline is rarely set to "now."
- In stock usage the consumer calls `Ack` synchronously inside the
  listener, on the `process` goroutine, so acks happen while messages are
  flowing - anti-correlated with the idle-deadline window.

Both protections disappear when the stream is mostly idle (the sink parks at
the 300ms timeout, constantly toggling the deadline) and the consumer acks
from a separate goroutine on a timer, which decouples ack timing from message
arrival. Then writes routinely land in the dangerous window.

## Fix

Add a `connMu` mutex on `stream` and hold it around both sides:

- the `ReceiveMessage` read in `sinkLoop` (the deadline-toggle window is
  fully contained by `ReceiveMessage`'s deferred `Unwatch`), released
  before the channel dispatch so acks never block the sink and vice versa;
- every standby status update, via a new `sendStandbyStatusUpdate` helper
  that all three write sites (idle keepalive, reply-on-request, consumer
  `Ack`) route through.

Read and write are now mutually exclusive, so a write can never observe the
read's transient deadline. `connMu` is always acquired before `mu`, never the
reverse. Cost is negligible: under load the lock is held only for the brief
read; when idle it is held up to 300ms, but there is nothing to ack then.