### PR TITLE
Avoid panic on replication stream receive failure

### DIFF
--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -289,16 +289,16 @@ func (s *stream) sink(ctx context.Context) {
 
 	s.sinkEnd <- struct{}{}
 	if !s.closed.Load() {
-		s.Close(ctx)
 		if corrupted {
-			panic("corrupted connection")
+			logger.Error("postgres stream connection corrupted; closing stream")
 		}
+		s.Close(ctx)
 	}
 }
 
 // sinkLoop reads raw replication messages and dispatches them until the
 // connection is closed or a fatal error occurs. It returns true when the
-// connection is in a corrupted state and the caller should panic.
+// connection is in a corrupted state.
 func (s *stream) sinkLoop(ctx context.Context, buf *messageBuffer, streamBuf *streamTxBuffer) (corrupted bool) {
 	for {
 		msgCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(300*time.Millisecond))

--- a/pq/replication/stream_test.go
+++ b/pq/replication/stream_test.go
@@ -66,6 +66,31 @@ func TestStreamSinkExitStopsProcessor(t *testing.T) {
 	}
 }
 
+func TestStreamSinkReceiveErrorClosesWithoutPanic(t *testing.T) {
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+
+	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(*ListenerContext) {}).(*stream)
+	stream.conn = receiveErrorConn{}
+	stream.processStarted.Store(true)
+
+	go stream.process(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		stream.sink(context.Background())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("sink did not finish after receive error")
+	}
+	if !stream.closed.Load() {
+		t.Fatal("stream was not closed after receive error")
+	}
+}
+
 func requireCloseReturns(t *testing.T, stream Streamer, msg string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Replication receive failures currently mark the stream as corrupted and then panic from the sink goroutine. That panic is not recoverable by callers and can crash the host process for ordinary transport failures such as a closed socket or unexpected EOF.

This change keeps the existing stream shutdown behavior but replaces the internal goroutine panic with an error log before closing the stream. It deliberately does not add reconnect semantics; reconnect/error-surfacing can be handled separately because that changes the connector lifecycle contract.

## Technical explanation

When `sinkLoop` returns `corrupted=true`, `sink` now logs `postgres stream connection corrupted; closing stream` and calls `Close` instead of panicking. The existing close path still closes the message channel and stops the processor.

A regression test exercises the non-explicit-close receive-error path. The previous behavior would panic from the sink goroutine; the new behavior closes the stream cleanly.

## Tests

- `mise x go@1.23.2 -- go test ./pq/replication`
- `mise x go@1.23.2 -- go test ./...`