### PR TITLE
fix: skip empty confirmed_flush_lsn when decoding slot info

### DIFF
--- a/pq/slot/slot.go
+++ b/pq/slot/slot.go
@@ -192,7 +192,9 @@ func decodeSlotInfoResult(result *pgconn.Result) (*Info, error) {
 			return nil, err
 		}
 
-		if v == nil {
+		// NULL/empty LSN columns (e.g. confirmed_flush_lsn on a physical or
+		// not-yet-reserved slot) must be skipped; ParseLSN("") returns a cryptic EOF.
+		if v == nil || v == "" {
 			continue
 		}
 

--- a/pq/slot/slot_test.go
+++ b/pq/slot/slot_test.go
@@ -1,0 +1,39 @@
+package slot
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// A physical / not-yet-reserved slot reports an empty confirmed_flush_lsn.
+// It must not blow up with a cryptic "lsn parse: EOF"; the empty column is
+// skipped and the logical-type check yields a clear error instead.
+func TestDecodeSlotInfoResult_EmptyConfirmedFlushLSN(t *testing.T) {
+	result := &pgconn.Result{
+		FieldDescriptions: []pgconn.FieldDescription{
+			{Name: "slot_name", DataTypeOID: pgtype.TextOID},
+			{Name: "slot_type", DataTypeOID: pgtype.TextOID},
+			{Name: "restart_lsn", DataTypeOID: pgtype.TextOID},
+			{Name: "confirmed_flush_lsn", DataTypeOID: pgtype.TextOID},
+		},
+		Rows: [][][]byte{{
+			[]byte("contents_to_contentmedias_slot"),
+			[]byte("physical"),
+			[]byte("0/1A2B3C4"),
+			[]byte(""), // NULL pg_lsn decoded as empty string
+		}},
+	}
+
+	info, err := decodeSlotInfoResult(result)
+	if err != nil {
+		t.Fatalf("expected empty confirmed_flush_lsn to be skipped, got: %v", err)
+	}
+	if info.ConfirmedFlushLSN != 0 {
+		t.Fatalf("expected zero ConfirmedFlushLSN, got: %v", info.ConfirmedFlushLSN)
+	}
+	if info.Type != Physical {
+		t.Fatalf("expected Physical type, got: %v", info.Type)
+	}
+}


### PR DESCRIPTION
## Summary
- Bir physical ya da henüz reserve edilmemiş replication slot, boş bir `confirmed_flush_lsn` döndürür. Bu değer `ParseLSN("")`'e düşüp anlamsız `lsn parse: EOF` hatası veriyordu.
- `decodeSlotInfoResult` artık NULL/boş LSN kolonlarını atlıyor; böylece `infoLocked`'taki logical-tip kontrolü "must be logical but it is physical" gibi net bir hata verebiliyor.

## Repro
Var olan slot physical/bozuk durumdayken connector start şu zincirle patlıyordu:
`(*Slot).Create → infoLocked → decodeSlotInfoResult → parse confirmed_flush_lsn → ParseLSN: lsn parse: EOF`

## Test plan
- [x] `go test ./pq/slot/ -run TestDecodeSlotInfoResult -v` (boş `confirmed_flush_lsn` artık EOF vermiyor, physical tip net hata)
- [x] `go build ./...`
- [ ] `make test/integration` (container runtime gerektirir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)