### PR TITLE
fix: Global variable breaks package when there are multiple slots

### DIFF
--- a/pq/message/message.go
+++ b/pq/message/message.go
@@ -33,9 +33,13 @@ var ErrorByteNotSupported = errors.New("message byte not supported")
 
 type Type uint8
 
-var streamedTransaction bool
-
-func New(data []byte, serverTime time.Time, relation map[uint32]*format.Relation) (any, error) {
+// New decodes a single pgoutput logical replication message. streamedTransaction
+// reports whether the stream is currently inside a streamed in-progress
+// transaction chunk (proto v2), in which case DML and Relation messages carry an
+// XID prefix. The caller owns that state (it flips on the StreamStart/StreamStop/
+// StreamCommit/StreamAbort messages this function returns) — it must NOT be
+// process-global, since one process may run several replication streams.
+func New(data []byte, streamedTransaction bool, serverTime time.Time, relation map[uint32]*format.Relation) (any, error) {
 	switch Type(data[0]) {
 	case BeginByte:
 		return format.NewBegin(data)
@@ -50,16 +54,12 @@ func New(data []byte, serverTime time.Time, relation map[uint32]*format.Relation
 	case TruncateByte:
 		return format.NewTruncate(data, streamedTransaction, relation, serverTime)
 	case StreamStartByte:
-		streamedTransaction = true
 		return format.NewStreamStart(data)
 	case StreamStopByte:
-		streamedTransaction = false
 		return &format.StreamStop{}, nil
 	case StreamAbortByte:
-		streamedTransaction = false
 		return format.NewStreamAbort(data)
 	case StreamCommitByte:
-		streamedTransaction = false
 		return format.NewStreamCommit(data)
 	case RelationByte:
 		msg, err := format.NewRelation(data, streamedTransaction)

--- a/pq/message/message_test.go
+++ b/pq/message/message_test.go
@@ -21,7 +21,7 @@ func TestNewDecodesTruncate(t *testing.T) {
 		0, 0, 0, 42,
 	}
 
-	msg, err := New(data, now, relations)
+	msg, err := New(data, false, now, relations)
 
 	require.NoError(t, err)
 	truncate, ok := msg.(*format.Truncate)
@@ -31,4 +31,34 @@ func TestNewDecodesTruncate(t *testing.T) {
 	assert.Equal(t, []*format.Relation{relations[42]}, truncate.Relations)
 	assert.False(t, truncate.Cascade)
 	assert.True(t, truncate.RestartIdentity)
+}
+
+// A Relation message inside a streamed transaction chunk carries a 4-byte XID
+// after the type byte. It must be decoded with the caller-provided flag — with
+// the wrong flag the offsets misalign and the decode reads past the buffer.
+func TestNewDecodesStreamedRelation(t *testing.T) {
+	relations := map[uint32]*format.Relation{}
+	data := []byte{
+		'R',
+		0, 0, 4, 210, // XID 1234
+		0, 0, 64, 6, // OID 16390
+		'p', 'u', 'b', 'l', 'i', 'c', 0,
+		't', 0,
+		'd', // replica identity
+		0, 1, // column count
+		1, 'i', 'd', 0, 0, 0, 0, 23, 255, 255, 255, 255,
+	}
+
+	msg, err := New(data, true, time.Now(), relations)
+
+	require.NoError(t, err)
+	rel, ok := msg.(*format.Relation)
+	require.True(t, ok)
+	assert.Equal(t, uint32(1234), rel.XID)
+	assert.Equal(t, uint32(16390), rel.OID)
+	assert.Equal(t, "public", rel.Namespace)
+	assert.Equal(t, "t", rel.Name)
+	require.Len(t, rel.Columns, 1)
+	assert.Equal(t, "id", rel.Columns[0].Name)
+	assert.Equal(t, rel, relations[16390])
 }

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -411,7 +411,7 @@ func (s *stream) handleXLogData(data []byte, buf *messageBuffer, streamBuf *stre
 	s.UpdateXLogPos(xld.ServerWALEnd)
 	s.metric.SetCDCLatency(time.Now().UTC().Sub(xld.ServerTime).Nanoseconds())
 
-	decodedMsg, err := message.New(xld.WALData, xld.ServerTime, s.relation)
+	decodedMsg, err := message.New(xld.WALData, streamBuf.streaming, xld.ServerTime, s.relation)
 	if err != nil || decodedMsg == nil {
 		logger.Debug("wal data message parsing error", "error", err)
 		return


### PR DESCRIPTION
If a single process tries to handle multiple replication slots it might read the cdc content incorrectly causing a crash.

we already use this fix in production so I it seems to work well

```
panic: runtime error: index out of range [364] with length 364
  goroutine 357 [running]:
  github.com/Trendyol/go-pq-cdc/pq/message/format.(*Relation).decode(0xc0014000f0, {0xc000e5a01e, 0x16c?, 0x41ca66?}, 0xd8?)
          github.com/Trendyol/go-pq-cdc@v1.9.11-0.20260522073922-ebadfbc11b43/pq/message/format/relation.go:71 +0x5ea
  github.com/Trendyol/go-pq-cdc/pq/message/format.NewRelation({0xc000e5a01e, 0x16c, 0x16c}, 0x0)
          github.com/Trendyol/go-pq-cdc@v1.9.11-0.20260522073922-ebadfbc11b43/pq/message/format/relation.go:23 +0x4c
  github.com/Trendyol/go-pq-cdc/pq/message.New({0xc000e5a01e, 0x16c, 0x16c}, {0x20f4dfd8?, 0xee1dbeea4?, 0x0?}, 0xc001395620)
          github.com/Trendyol/go-pq-cdc@v1.9.11-0.20260522073922-ebadfbc11b43/pq/message/message.go:65 +0x1cf
  github.com/Trendyol/go-pq-cdc/pq/replication.(*stream).handleXLogData(0xc001514008, {0xc000e5a006?, 0xc000e4fc10?, 0x11e1a300?},
  0xc0013f5f98, 0xc0013f5f88)
          github.com/Trendyol/go-pq-cdc@v1.9.11-0.20260522073922-ebadfbc11b43/pq/replication/stream.go:414 +0x432
  github.com/Trendyol/go-pq-cdc/pq/replication.(*stream).sinkLoop(0xc001514008, {0x7541708, 0xc0010e4050}, 0xc0013f5f98,
  0xc0013f5f88)
          github.com/Trendyol/go-pq-cdc@v1.9.11-0.20260522073922-ebadfbc11b43/pq/replication/stream.go:345 +0x1ac
  github.com/Trendyol/go-pq-cdc/pq/replication.(*stream).sink(0xc001514008, {0x7541708, 0xc0010e4050})
          github.com/Trendyol/go-pq-cdc@v1.9.11-0.20260522073922-ebadfbc11b43/pq/replication/stream.go:285 +0x9d
  created by github.com/Trendyol/go-pq-cdc/pq/replication.(*stream).Open in goroutine 169
          github.com/Trendyol/go-pq-cdc@v1.9.11-0.20260522073922-ebadfbc11b43/pq/replication/stream.go:137 +0x17c
```