### PR TITLE
fix: flush confirmedXLogPos on SIGTERM

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -51,6 +51,7 @@ type connector struct {
 	snapshotter        *snapshot.Snapshotter
 	listenerFunc       replication.ListenerFunc
 	once               sync.Once
+	closeOnce          sync.Once
 }
 
 func NewConnectorWithConfigFile(ctx context.Context, configFilePath string, listenerFunc replication.ListenerFunc) (Connector, error) {
@@ -577,42 +578,46 @@ func (c *connector) WaitUntilReady(ctx context.Context) error {
 }
 
 func (c *connector) Close() {
-	// Create a context with timeout for graceful cleanup
-	// 30 seconds should be sufficient for closing connections and cleanup operations
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	// Make close idempotent
+	c.closeOnce.Do(func() {
+		// Create a context with timeout for graceful cleanup
+		// 30 seconds should be sufficient for closing connections and cleanup operations
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 
-	logger.Debug("[connector] closing connector")
+		logger.Debug("[connector] closing connector")
 
-	// Close signal channels
-	if !isClosed(c.cancelCh) {
-		close(c.cancelCh)
-	}
-	if !isClosed(c.readyCh) {
-		close(c.readyCh)
-	}
+		// Close signal channels
+		signal.Stop(c.cancelCh)
+		if !isClosed(c.cancelCh) {
+			close(c.cancelCh)
+		}
+		if !isClosed(c.readyCh) {
+			close(c.readyCh)
+		}
 
-	// Close snapshotter connections if still open (fallback for crash/error scenarios)
-	// Normal flow: connections are already closed in finalizeSnapshot() when snapshot completes
-	if c.snapshotter != nil {
-		c.snapshotter.Close(ctx)
-	}
+		// Close snapshotter connections if still open (fallback for crash/error scenarios)
+		// Normal flow: connections are already closed in finalizeSnapshot() when snapshot completes
+		if c.snapshotter != nil {
+			c.snapshotter.Close(ctx)
+		}
 
-	// Close replication slot and stream (nil in snapshot_only mode)
-	if c.slot != nil {
-		c.slot.Close(ctx)
-	}
-	if c.heartbeat != nil {
-		c.heartbeat.Close(ctx)
-	}
-	if c.stream != nil {
-		c.stream.Close(ctx)
-	}
+		// Close replication slot and stream (nil in snapshot_only mode)
+		if c.slot != nil {
+			c.slot.Close(ctx)
+		}
+		if c.heartbeat != nil {
+			c.heartbeat.Close(ctx)
+		}
+		if c.stream != nil {
+			c.stream.Close(ctx)
+		}
 
-	// Shutdown HTTP server
-	c.server.Shutdown()
+		// Shutdown HTTP server
+		c.server.Shutdown()
 
-	logger.Info("[connector] connector closed successfully")
+		logger.Info("[connector] connector closed successfully")
+	})
 }
 
 func (c *connector) GetConfig() *config.Config {

--- a/integration_test/copy_protocol_test.go
+++ b/integration_test/copy_protocol_test.go
@@ -2,6 +2,10 @@ package integration
 
 import (
 	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
 	cdc "github.com/Trendyol/go-pq-cdc"
 	"github.com/Trendyol/go-pq-cdc/config"
 	"github.com/Trendyol/go-pq-cdc/pq/message/format"
@@ -9,9 +13,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
-	"sync/atomic"
-	"testing"
-	"time"
 )
 
 func TestCopyProtocol(t *testing.T) {
@@ -47,7 +48,7 @@ func TestCopyProtocol(t *testing.T) {
 			t.FailNow()
 		}
 
-		connector2, err := cdc.NewConnector(ctx, cdcCfg, handlerFunc)
+		connector2, err := cdc.NewConnector(ctx, cdc2Cfg, handlerFunc)
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
@@ -60,6 +61,7 @@ func TestCopyProtocol(t *testing.T) {
 
 		t.Cleanup(func() {
 			pool.Close()
+			connector.Close()
 			connector2.Close()
 			assert.NoError(t, RestoreDB(ctx))
 		})

--- a/integration_test/sigterm_lsn_flush_test.go
+++ b/integration_test/sigterm_lsn_flush_test.go
@@ -1,0 +1,113 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	cdc "github.com/Trendyol/go-pq-cdc"
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/pq/replication"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSIGTERMFlushesPendingConfirmedLSN(t *testing.T) {
+	ctx := context.Background()
+
+	cdcCfg := Config
+	cdcCfg.Slot.Name = "slot_test_sigterm_flush"
+
+	forEachProtoVersion(t, cdcCfg, func(t *testing.T, cdcCfg config.Config) {
+		postgresConn, err := newPostgresConn()
+		require.NoError(t, err)
+
+		require.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg))
+
+		handlerConn, err := newPostgresConn()
+		require.NoError(t, err)
+
+		var once sync.Once
+		var confirmedBefore string
+		ackCheckedBeforeSignal := make(chan struct{})
+		handlerErr := make(chan error, 1)
+		handlerFunc := func(lCtx *replication.ListenerContext) {
+			if err := lCtx.Ack(); err != nil {
+				handlerErr <- err
+				return
+			}
+			_, confirmedAfterAck, err := readSlotLSNs(ctx, handlerConn, cdcCfg.Slot.Name)
+			if err != nil {
+				handlerErr <- err
+				return
+			}
+			if confirmedAfterAck != confirmedBefore {
+				handlerErr <- fmt.Errorf(
+					"confirmed_flush_lsn advanced before SIGTERM: before=%s after_ack=%s",
+					confirmedBefore,
+					confirmedAfterAck,
+				)
+				return
+			}
+			once.Do(func() {
+				close(ackCheckedBeforeSignal)
+			})
+		}
+
+		connector, err := cdc.NewConnector(ctx, cdcCfg, handlerFunc)
+		require.NoError(t, err)
+
+		startDone := make(chan struct{})
+		go func() {
+			defer close(startDone)
+			connector.Start(ctx)
+		}()
+
+		t.Cleanup(func() {
+			connector.Close()
+			require.NoError(t, handlerConn.Close(ctx))
+			_ = pgExec(ctx, postgresConn, fmt.Sprintf("DROP PUBLICATION IF EXISTS %s", cdcCfg.Publication.Name))
+			_ = pgExec(ctx, postgresConn, fmt.Sprintf("SELECT pg_drop_replication_slot('%s') WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '%s')", cdcCfg.Slot.Name, cdcCfg.Slot.Name))
+			require.NoError(t, RestoreDB(ctx))
+			require.NoError(t, postgresConn.Close(ctx))
+		})
+
+		waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		require.NoError(t, connector.WaitUntilReady(waitCtx))
+		cancel()
+
+		_, confirmedBefore, err = readSlotLSNs(ctx, postgresConn, cdcCfg.Slot.Name)
+		require.NoError(t, err)
+
+		require.NoError(t, pgExec(ctx, postgresConn, "INSERT INTO books(id, name) VALUES(9090, 'sigterm-flush')"))
+
+		select {
+		case <-ackCheckedBeforeSignal:
+		case err := <-handlerErr:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for insert ack check")
+		}
+
+		require.NoError(t, syscall.Kill(os.Getpid(), syscall.SIGTERM))
+
+		select {
+		case <-startDone:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timeout waiting for connector to stop after SIGTERM")
+		}
+
+		connector.Close()
+
+		require.Eventually(t, func() bool {
+			_, confirmedAfter, err := readSlotLSNs(ctx, postgresConn, cdcCfg.Slot.Name)
+			if err != nil {
+				return false
+			}
+			return confirmedAfter != "" && confirmedAfter != confirmedBefore
+		}, 5*time.Second, 100*time.Millisecond, "expected confirmed_flush_lsn to advance during SIGTERM shutdown")
+	})
+}

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -584,6 +584,7 @@ func (s *stream) Close(ctx context.Context) {
 	}
 
 	if !s.conn.IsClosed() {
+		s.flushFinalStandbyStatusUpdate(ctx)
 		_ = s.conn.Close(ctx)
 		logger.Info("postgres connection closed")
 	}
@@ -718,6 +719,17 @@ func (s *stream) sendStandbyStatusUpdate(ctx context.Context) error {
 	s.connMu.Lock()
 	defer s.connMu.Unlock()
 	return SendStandbyStatusUpdate(ctx, s.conn, uint64(s.LoadXLogPos()), uint64(s.LoadConfirmedXLogPos()))
+}
+
+func (s *stream) flushFinalStandbyStatusUpdate(ctx context.Context) {
+	if s.LoadConfirmedXLogPos() == 0 {
+		return
+	}
+	if err := s.sendStandbyStatusUpdate(ctx); err != nil {
+		logger.Warn("final standby status update failed, updates may duplicate on restart", "error", err)
+		return
+	}
+	logger.Debug("final standby status update sent")
 }
 
 func SendStandbyStatusUpdate(_ context.Context, conn pq.Connection, walReceivedPosition, walFlushedPosition uint64) error {

--- a/pq/replication/stream_test.go
+++ b/pq/replication/stream_test.go
@@ -1,9 +1,11 @@
 package replication
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,6 +68,32 @@ func TestStreamSinkExitStopsProcessor(t *testing.T) {
 	}
 }
 
+func TestStreamCloseFlushesFinalConfirmedLSN(t *testing.T) {
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+
+	var written bytes.Buffer
+	conn := &standbyCaptureConn{
+		fe: pgproto3.NewFrontend(strings.NewReader(""), &written),
+	}
+
+	stream := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(*ListenerContext) {}).(*stream)
+	stream.conn = conn
+	stream.UpdateXLogPos(200)
+	stream.UpdateConfirmedXLogPos(150)
+
+	stream.Close(context.Background())
+
+	if written.Len() == 0 {
+		t.Fatal("expected final standby status update to be written")
+	}
+	if !bytes.Contains(written.Bytes(), []byte{StandbyStatusUpdateByteID}) {
+		t.Fatal("expected standby status update payload")
+	}
+	if !conn.closed {
+		t.Fatal("expected connection to be closed")
+	}
+}
+
 func requireCloseReturns(t *testing.T, stream Streamer, msg string) {
 	t.Helper()
 
@@ -105,5 +133,35 @@ func (receiveErrorConn) Frontend() *pgproto3.Frontend {
 }
 
 func (receiveErrorConn) Exec(context.Context, string) *pgconn.MultiResultReader {
+	return nil
+}
+
+type standbyCaptureConn struct {
+	fe     *pgproto3.Frontend
+	closed bool
+}
+
+func (c *standbyCaptureConn) Connect(context.Context) error {
+	return nil
+}
+
+func (c *standbyCaptureConn) IsClosed() bool {
+	return c.closed
+}
+
+func (c *standbyCaptureConn) Close(context.Context) error {
+	c.closed = true
+	return nil
+}
+
+func (c *standbyCaptureConn) ReceiveMessage(context.Context) (pgproto3.BackendMessage, error) {
+	return nil, errors.New("receive failed")
+}
+
+func (c *standbyCaptureConn) Frontend() *pgproto3.Frontend {
+	return c.fe
+}
+
+func (c *standbyCaptureConn) Exec(context.Context, string) *pgconn.MultiResultReader {
 	return nil
 }


### PR DESCRIPTION
## Summary

Flush the latest acknowledged LSN during stream shutdown before closing the replication connection.

Also make `connector.Close()` idempotent to prevent double-close side effects when callers close explicitly after signal-driven shutdown.

Fixes #148

## Test plan

- Added regression coverage for final standby status update on stream close.
- Added integration coverage for SIGTERM shutdown advancing `confirmed_flush_lsn`.