### PR TITLE
fix: bounds-check pgoutput decoders instead of panicking on truncated messages

### DIFF
--- a/pq/message/format/begin.go
+++ b/pq/message/format/begin.go
@@ -25,8 +25,8 @@ func NewBegin(data []byte) (*Begin, error) {
 func (b *Begin) decode(data []byte) error {
 	skipByte := 1
 
-	if len(data) < 20 {
-		return errors.Newf("begin message length must be at least 20 byte, but got %d", len(data))
+	if len(data) < 21 {
+		return errors.Newf("begin message length must be at least 21 byte, but got %d", len(data))
 	}
 
 	b.FinalLSN = pq.LSN(binary.BigEndian.Uint64(data[skipByte:]))

--- a/pq/message/format/begin_test.go
+++ b/pq/message/format/begin_test.go
@@ -45,7 +45,7 @@ func TestNewBegin(t *testing.T) {
 		// Then
 		require.Error(t, err)
 		assert.Nil(t, begin)
-		assert.Contains(t, err.Error(), "begin message length must be at least 20 byte")
+		assert.Contains(t, err.Error(), "begin message length must be at least 21 byte")
 	})
 
 	t.Run("should decode begin message with minimum valid length", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestBegin_decode(t *testing.T) {
 
 		// Then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "begin message length must be at least 20 byte")
+		assert.Contains(t, err.Error(), "begin message length must be at least 21 byte")
 	})
 
 	t.Run("should return error when data length is exactly 19 bytes", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestBegin_decode(t *testing.T) {
 
 		// Then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "begin message length must be at least 20 byte, but got 19")
+		assert.Contains(t, err.Error(), "begin message length must be at least 21 byte, but got 19")
 	})
 
 	t.Run("should decode when data length is exactly 21 bytes", func(t *testing.T) {

--- a/pq/message/format/commit.go
+++ b/pq/message/format/commit.go
@@ -26,8 +26,8 @@ func NewCommit(data []byte) (*Commit, error) {
 func (c *Commit) decode(data []byte) error {
 	skipByte := 1
 
-	if len(data) < 25 {
-		return errors.Newf("commit message length must be at least 25 byte, but got %d", len(data))
+	if len(data) < 26 {
+		return errors.Newf("commit message length must be at least 26 byte, but got %d", len(data))
 	}
 
 	c.Flags = data[skipByte]

--- a/pq/message/format/commit_test.go
+++ b/pq/message/format/commit_test.go
@@ -47,7 +47,7 @@ func TestNewCommit(t *testing.T) {
 		// Then
 		require.Error(t, err)
 		assert.Nil(t, commit)
-		assert.Contains(t, err.Error(), "commit message length must be at least 25 byte")
+		assert.Contains(t, err.Error(), "commit message length must be at least 26 byte")
 	})
 
 	t.Run("should decode commit message with minimum valid length", func(t *testing.T) {
@@ -149,7 +149,7 @@ func TestCommit_decode(t *testing.T) {
 
 		// Then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "commit message length must be at least 25 byte")
+		assert.Contains(t, err.Error(), "commit message length must be at least 26 byte")
 	})
 
 	t.Run("should return error when data length is exactly 24 bytes", func(t *testing.T) {
@@ -162,7 +162,7 @@ func TestCommit_decode(t *testing.T) {
 
 		// Then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "commit message length must be at least 25 byte, but got 24")
+		assert.Contains(t, err.Error(), "commit message length must be at least 26 byte, but got 24")
 	})
 
 	t.Run("should decode when data length is exactly 26 bytes", func(t *testing.T) {

--- a/pq/message/format/update.go
+++ b/pq/message/format/update.go
@@ -102,7 +102,7 @@ func (m *Update) decode(data []byte, streamedTransaction bool) error {
 		if m.OldTupleData != nil {
 			for i, col := range m.NewTupleData.Columns {
 				// because toasted columns not sent until the toasted column updated
-				if col.DataType == tuple.DataTypeToast {
+				if col.DataType == tuple.DataTypeToast && i < len(m.OldTupleData.Columns) {
 					m.NewTupleData.Columns[i] = m.OldTupleData.Columns[i]
 				}
 			}

--- a/pq/message/message.go
+++ b/pq/message/message.go
@@ -40,6 +40,9 @@ type Type uint8
 // StreamCommit/StreamAbort messages this function returns) — it must NOT be
 // process-global, since one process may run several replication streams.
 func New(data []byte, streamedTransaction bool, serverTime time.Time, relation map[uint32]*format.Relation) (any, error) {
+	if len(data) == 0 {
+		return nil, errors.New("empty message data")
+	}
 	switch Type(data[0]) {
 	case BeginByte:
 		return format.NewBegin(data)

--- a/pq/message/message_test.go
+++ b/pq/message/message_test.go
@@ -44,7 +44,7 @@ func TestNewDecodesStreamedRelation(t *testing.T) {
 		0, 0, 64, 6, // OID 16390
 		'p', 'u', 'b', 'l', 'i', 'c', 0,
 		't', 0,
-		'd', // replica identity
+		'd',  // replica identity
 		0, 1, // column count
 		1, 'i', 'd', 0, 0, 0, 0, 23, 255, 255, 255, 255,
 	}
@@ -61,4 +61,9 @@ func TestNewDecodesStreamedRelation(t *testing.T) {
 	require.Len(t, rel.Columns, 1)
 	assert.Equal(t, "id", rel.Columns[0].Name)
 	assert.Equal(t, rel, relations[16390])
+}
+
+func TestNewRejectsEmptyData(t *testing.T) {
+	_, err := New([]byte{}, false, time.Now(), map[uint32]*format.Relation{})
+	require.Error(t, err)
 }

--- a/pq/message/tuple/data.go
+++ b/pq/message/tuple/data.go
@@ -38,22 +38,33 @@ type RelationColumn struct {
 }
 
 func NewData(data []byte, tupleDataType uint8, skipByteLength int) (*Data, error) {
+	if skipByteLength >= len(data) {
+		return nil, errors.Newf("tuple data length must be at least %d byte, but got %d", skipByteLength+1, len(data))
+	}
 	if data[skipByteLength] != tupleDataType {
 		return nil, errors.New("invalid tuple data type: " + string(data[skipByteLength]))
 	}
 	skipByteLength++
 
 	d := &Data{}
-	d.Decode(data, skipByteLength)
+	if err := d.Decode(data, skipByteLength); err != nil {
+		return nil, err
+	}
 
 	return d, nil
 }
 
-func (d *Data) Decode(data []byte, skipByteLength int) {
+func (d *Data) Decode(data []byte, skipByteLength int) error {
+	if len(data) < skipByteLength+2 {
+		return errors.Newf("tuple data length must be at least %d byte, but got %d", skipByteLength+2, len(data))
+	}
 	d.ColumnNumber = binary.BigEndian.Uint16(data[skipByteLength:])
 	skipByteLength += 2
 
 	for range d.ColumnNumber {
+		if skipByteLength >= len(data) {
+			return errors.Newf("tuple data length must be at least %d byte, but got %d", skipByteLength+1, len(data))
+		}
 		col := new(DataColumn)
 		col.DataType = data[skipByteLength]
 		skipByteLength++
@@ -61,9 +72,15 @@ func (d *Data) Decode(data []byte, skipByteLength int) {
 		switch col.DataType {
 		case DataTypeNull, DataTypeToast:
 		case DataTypeText, DataTypeBinary:
+			if len(data) < skipByteLength+4 {
+				return errors.Newf("tuple data length must be at least %d byte, but got %d", skipByteLength+4, len(data))
+			}
 			col.Length = binary.BigEndian.Uint32(data[skipByteLength:])
 			skipByteLength += 4
 
+			if len(data) < skipByteLength+int(col.Length) {
+				return errors.Newf("tuple data length must be at least %d byte, but got %d", skipByteLength+int(col.Length), len(data))
+			}
 			col.Data = make([]byte, int(col.Length))
 			copy(col.Data, data[skipByteLength:])
 
@@ -73,6 +90,7 @@ func (d *Data) Decode(data []byte, skipByteLength int) {
 		d.Columns = append(d.Columns, col)
 	}
 	d.SkipByte = skipByteLength
+	return nil
 }
 
 func (d *Data) DecodeWithColumn(columns []RelationColumn) (map[string]any, error) {

--- a/pq/message/tuple/data_test.go
+++ b/pq/message/tuple/data_test.go
@@ -57,6 +57,33 @@ func TestNewData(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid tuple data type: D")
 	})
+
+	t.Run("should return error when text column has no length bytes", func(t *testing.T) {
+		truncated := []byte{tupleDataType, 0, 1, DataTypeText}
+		_, err := NewData(truncated, tupleDataType, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tuple data length")
+	})
+
+	t.Run("should return error when column data is shorter than its length", func(t *testing.T) {
+		truncated := []byte{tupleDataType, 0, 1, DataTypeText, 0, 0, 0, 10, 'a', 'b'}
+		_, err := NewData(truncated, tupleDataType, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tuple data length")
+	})
+
+	t.Run("should return error when column count exceeds data", func(t *testing.T) {
+		truncated := []byte{tupleDataType, 0, 2, DataTypeNull}
+		_, err := NewData(truncated, tupleDataType, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tuple data length")
+	})
+
+	t.Run("should return error when tuple data ends before type byte", func(t *testing.T) {
+		_, err := NewData([]byte{0x00}, tupleDataType, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tuple data length")
+	})
 }
 
 func TestData_DecodeWithColumn(t *testing.T) {


### PR DESCRIPTION
## Summary

A single malformed or truncated pgoutput frame currently panics the decoders, which unwinds the `sink` goroutine and takes the whole process down instead of hitting the log-and-skip path in `handleXLogData`. This makes the decode paths return errors instead:

- `message.New` rejects empty WAL data instead of indexing `data[0]`
- `tuple.Data.Decode` bounds-checks the column type, length, and data reads (and no longer allocates a wire-controlled length that exceeds the remaining buffer)
- `Begin`/`Commit` minimum length guards were off by one (20 should be 21, 25 should be 26; the boundary tests in the repo already document 21/26 as the true minimums)
- the update TOAST merge no longer indexes the old tuple past its length

Fixes #152

## Tests

Added cases for the truncated frames from the issue; each one panics with index out of range without the fix. `go test ./pq/message/...` is green.
