### PR TITLE
fix: harden pgoutput decoders so a malformed frame cannot crash the process

### DIFF
--- a/pq/message/format/begin.go
+++ b/pq/message/format/begin.go
@@ -25,8 +25,8 @@ func NewBegin(data []byte) (*Begin, error) {
 func (b *Begin) decode(data []byte) error {
 	skipByte := 1
 
-	if len(data) < 20 {
-		return errors.Newf("begin message length must be at least 20 byte, but got %d", len(data))
+	if len(data) < 21 {
+		return errors.Newf("begin message length must be at least 21 byte, but got %d", len(data))
 	}
 
 	b.FinalLSN = pq.LSN(binary.BigEndian.Uint64(data[skipByte:]))

--- a/pq/message/format/begin_test.go
+++ b/pq/message/format/begin_test.go
@@ -45,7 +45,7 @@ func TestNewBegin(t *testing.T) {
 		// Then
 		require.Error(t, err)
 		assert.Nil(t, begin)
-		assert.Contains(t, err.Error(), "begin message length must be at least 20 byte")
+		assert.Contains(t, err.Error(), "begin message length must be at least 21 byte")
 	})
 
 	t.Run("should decode begin message with minimum valid length", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestBegin_decode(t *testing.T) {
 
 		// Then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "begin message length must be at least 20 byte")
+		assert.Contains(t, err.Error(), "begin message length must be at least 21 byte")
 	})
 
 	t.Run("should return error when data length is exactly 19 bytes", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestBegin_decode(t *testing.T) {
 
 		// Then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "begin message length must be at least 20 byte, but got 19")
+		assert.Contains(t, err.Error(), "begin message length must be at least 21 byte, but got 19")
 	})
 
 	t.Run("should decode when data length is exactly 21 bytes", func(t *testing.T) {
@@ -150,4 +150,18 @@ func TestBegin_decode(t *testing.T) {
 		assert.Equal(t, pgTimeForTest(0), begin.CommitTime)
 		assert.Equal(t, uint32(0), begin.Xid)
 	})
+}
+
+// The old guard accepted exactly 20 bytes and the Xid read then walked past the
+// buffer. Length 20 is the critical boundary for begin messages: it must fail
+// with the length error, never panic.
+func TestBegin_ExactlyTwentyBytesReturnsError(t *testing.T) {
+	data := make([]byte, 20)
+	data[0] = 'B'
+
+	begin, err := NewBegin(data)
+
+	require.Error(t, err)
+	assert.Nil(t, begin)
+	assert.Contains(t, err.Error(), "begin message length must be at least 21 byte, but got 20")
 }

--- a/pq/message/format/commit.go
+++ b/pq/message/format/commit.go
@@ -26,8 +26,8 @@ func NewCommit(data []byte) (*Commit, error) {
 func (c *Commit) decode(data []byte) error {
 	skipByte := 1
 
-	if len(data) < 25 {
-		return errors.Newf("commit message length must be at least 25 byte, but got %d", len(data))
+	if len(data) < 26 {
+		return errors.Newf("commit message length must be at least 26 byte, but got %d", len(data))
 	}
 
 	c.Flags = data[skipByte]

--- a/pq/message/format/commit_test.go
+++ b/pq/message/format/commit_test.go
@@ -47,7 +47,7 @@ func TestNewCommit(t *testing.T) {
 		// Then
 		require.Error(t, err)
 		assert.Nil(t, commit)
-		assert.Contains(t, err.Error(), "commit message length must be at least 25 byte")
+		assert.Contains(t, err.Error(), "commit message length must be at least 26 byte")
 	})
 
 	t.Run("should decode commit message with minimum valid length", func(t *testing.T) {
@@ -149,7 +149,7 @@ func TestCommit_decode(t *testing.T) {
 
 		// Then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "commit message length must be at least 25 byte")
+		assert.Contains(t, err.Error(), "commit message length must be at least 26 byte")
 	})
 
 	t.Run("should return error when data length is exactly 24 bytes", func(t *testing.T) {
@@ -162,7 +162,7 @@ func TestCommit_decode(t *testing.T) {
 
 		// Then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "commit message length must be at least 25 byte, but got 24")
+		assert.Contains(t, err.Error(), "commit message length must be at least 26 byte, but got 24")
 	})
 
 	t.Run("should decode when data length is exactly 26 bytes", func(t *testing.T) {
@@ -203,4 +203,17 @@ func TestCommit_decode(t *testing.T) {
 		assert.Equal(t, pq.LSN(512), commit.TransactionEndLSN)
 		assert.Equal(t, pgTimeForTest(1677721600), commit.CommitTime)
 	})
+}
+
+// Same boundary story for commit: the old guard accepted exactly 25 bytes and
+// the timestamp read then walked past the buffer.
+func TestCommit_ExactlyTwentyFiveBytesReturnsError(t *testing.T) {
+	data := make([]byte, 25)
+	data[0] = 'C'
+
+	commit, err := NewCommit(data)
+
+	require.Error(t, err)
+	assert.Nil(t, commit)
+	assert.Contains(t, err.Error(), "commit message length must be at least 26 byte, but got 25")
 }

--- a/pq/message/format/relation.go
+++ b/pq/message/format/relation.go
@@ -55,38 +55,62 @@ func (m *Relation) decode(data []byte, streamedTransaction bool) error {
 
 	m.Name, usedByteCount = decodeString(data[skipByte:])
 	if usedByteCount < 0 {
-		return errors.New("relation message namespace decode error")
+		return errors.New("relation message name decode error")
 	}
 	skipByte += usedByteCount
 
+	if skipByte >= len(data) {
+		return errors.New("relation message missing replica identity")
+	}
 	m.ReplicaID = data[skipByte]
 	skipByte++
 
+	if len(data)-skipByte < 2 {
+		return errors.New("relation message missing column count")
+	}
 	m.ColumnNumbers = binary.BigEndian.Uint16(data[skipByte:])
 	skipByte += 2
 
 	m.Columns = make([]tuple.RelationColumn, m.ColumnNumbers)
 	for i := range m.Columns {
-		col := tuple.RelationColumn{}
-		col.Flags = data[skipByte]
-		skipByte++
-
-		col.Name, usedByteCount = decodeString(data[skipByte:])
-		if usedByteCount < 0 {
-			return errors.Newf("relation message columns[%d].name decode error", i)
+		col, used, err := decodeRelationColumn(data[skipByte:], i)
+		if err != nil {
+			return err
 		}
-		skipByte += usedByteCount
-
-		col.DataType = binary.BigEndian.Uint32(data[skipByte:])
-		skipByte += 4
-
-		col.TypeModifier = binary.BigEndian.Uint32(data[skipByte:])
-		skipByte += 4
-
 		m.Columns[i] = col
+		skipByte += used
 	}
 
 	return nil
+}
+
+// decodeRelationColumn decodes one column descriptor from the start of data and
+// returns the column together with the number of bytes it consumed.
+func decodeRelationColumn(data []byte, i int) (tuple.RelationColumn, int, error) {
+	var col tuple.RelationColumn
+
+	if len(data) == 0 {
+		return col, 0, errors.Newf("relation message columns[%d] missing flags", i)
+	}
+	col.Flags = data[0]
+	skip := 1
+
+	name, used := decodeString(data[skip:])
+	if used < 0 {
+		return col, 0, errors.Newf("relation message columns[%d].name decode error", i)
+	}
+	col.Name = name
+	skip += used
+
+	if len(data)-skip < 8 {
+		return col, 0, errors.Newf("relation message columns[%d] missing type info", i)
+	}
+	col.DataType = binary.BigEndian.Uint32(data[skip:])
+	skip += 4
+	col.TypeModifier = binary.BigEndian.Uint32(data[skip:])
+	skip += 4
+
+	return col, skip, nil
 }
 
 func decodeString(data []byte) (string, int) {

--- a/pq/message/format/relation_test.go
+++ b/pq/message/format/relation_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Trendyol/go-pq-cdc/pq/message/tuple"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRelation_New(t *testing.T) {
@@ -39,4 +40,69 @@ func TestRelation_New(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, rel)
+}
+
+func TestRelation_TruncatedReturnsError(t *testing.T) {
+	// 'R', OID(4), namespace "a\0", name "b\0", then nothing where the replica
+	// identity byte is expected. This passes the only length guard (len < 8).
+	data := []byte{'R', 0, 0, 0, 1, 'a', 0, 'b', 0}
+	_, err := NewRelation(data, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "relation message missing replica identity")
+}
+
+// Every truncation point in the relation decoder must surface as an error with a
+// message naming the missing field, so a wrong or reordered guard is caught.
+func TestRelation_DecodeGuardsOnTruncatedInput(t *testing.T) {
+	// 'R', OID(4), namespace "a\0", name "b\0". Everything after this prefix is
+	// appended per case.
+	prefix := []byte{'R', 0, 0, 0, 1, 'a', 0, 'b', 0}
+	withTail := func(tail ...byte) []byte {
+		return append(append([]byte{}, prefix...), tail...)
+	}
+
+	cases := []struct {
+		name     string
+		data     []byte
+		streamed bool
+		wantErr  string
+	}{
+		{name: "missing replica identity", data: withTail(), wantErr: "relation message missing replica identity"},
+		{name: "missing column count", data: withTail(1), wantErr: "relation message missing column count"},
+		{name: "one byte column count", data: withTail(1, 0), wantErr: "relation message missing column count"},
+		{name: "first column missing flags", data: withTail(1, 0, 1), wantErr: "relation message columns[0] missing flags"},
+		{name: "first column name unterminated", data: withTail(1, 0, 1, 1, 'x'), wantErr: "relation message columns[0].name decode error"},
+		{name: "first column missing type info", data: withTail(1, 0, 1, 1, 'x', 0, 0, 0, 0, 23), wantErr: "relation message columns[0] missing type info"},
+		{name: "second column missing flags", data: withTail(1, 0, 2, 1, 'x', 0, 0, 0, 0, 23, 255, 255, 255, 255), wantErr: "relation message columns[1] missing flags"},
+		{name: "namespace unterminated", data: []byte{'R', 0, 0, 0, 1, 'a', 'b', 'c'}, wantErr: "relation message namespace decode error"},
+		{name: "name unterminated", data: []byte{'R', 0, 0, 0, 1, 'a', 0, 'b', 'c'}, wantErr: "relation message name decode error"},
+		{name: "header too short", data: []byte{'R', 0, 0}, wantErr: "relation message length must be at least 8 byte, but got 3"},
+		{name: "streamed header too short", data: []byte{'R', 0, 0, 0, 1}, streamed: true, wantErr: "streamed transaction relation message length must be at least 12 byte, but got 5"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rel, err := NewRelation(tc.data, tc.streamed)
+
+			require.Error(t, err)
+			assert.Nil(t, rel)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// The smallest well formed relation message: empty namespace, empty name, and
+// zero columns. It must decode, proving the guards do not reject valid input.
+func TestRelation_MinimalZeroColumnMessageDecodes(t *testing.T) {
+	data := []byte{'R', 0, 0, 0, 1, 0, 0, 'd', 0, 0}
+
+	rel, err := NewRelation(data, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), rel.OID)
+	assert.Empty(t, rel.Namespace)
+	assert.Empty(t, rel.Name)
+	assert.Equal(t, uint8('d'), rel.ReplicaID)
+	assert.Equal(t, uint16(0), rel.ColumnNumbers)
+	assert.Empty(t, rel.Columns)
 }

--- a/pq/message/format/truncate.go
+++ b/pq/message/format/truncate.go
@@ -58,14 +58,15 @@ func (m *Truncate) decode(data []byte, streamedTransaction bool) error {
 		return errors.Newf("truncate message length must be at least %d byte, but got %d", skipByte+5, len(data))
 	}
 
-	relationCount := int(binary.BigEndian.Uint32(data[skipByte:]))
+	relationCountU := binary.BigEndian.Uint32(data[skipByte:])
 	skipByte += 4
 	m.Options = data[skipByte]
 	skipByte++
 
-	if len(data) < skipByte+(relationCount*4) {
-		return errors.Newf("truncate message relation IDs length must be %d byte, but got %d", relationCount*4, len(data)-skipByte)
+	if uint64(relationCountU)*4 > uint64(len(data)-skipByte) {
+		return errors.Newf("truncate message relation IDs length must be %d byte, but got %d", uint64(relationCountU)*4, len(data)-skipByte)
 	}
+	relationCount := int(relationCountU)
 
 	m.Cascade = m.Options&TruncateOptionCascade != 0
 	m.RestartIdentity = m.Options&TruncateOptionRestartIdentity != 0

--- a/pq/message/format/truncate_test.go
+++ b/pq/message/format/truncate_test.go
@@ -92,4 +92,57 @@ func TestTruncate_New(t *testing.T) {
 		assert.Nil(t, msg)
 		assert.Contains(t, err.Error(), "truncate message relation IDs length")
 	})
+
+	t.Run("returns error when relation count is absurdly large", func(t *testing.T) {
+		data := []byte{
+			'T',
+			0xFF, 0xFF, 0xFF, 0xFF, // relation count
+			0, // options
+		}
+
+		msg, err := NewTruncate(data, false, relations, now)
+
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		// The wanted size is the full unsigned width times four, which proves the
+		// count no longer wraps through int on 32 bit builds.
+		assert.Contains(t, err.Error(), "truncate message relation IDs length must be 17179869180 byte")
+	})
+}
+
+func TestTruncate_StreamedGuards(t *testing.T) {
+	now := time.Now()
+	relations := map[uint32]*Relation{}
+
+	t.Run("returns error when streamed truncate is too short", func(t *testing.T) {
+		msg, err := NewTruncate([]byte{'T', 0, 0, 0, 9}, true, relations, now)
+
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		assert.Contains(t, err.Error(), "streamed transaction truncate message length must be at least 10 byte, but got 5")
+	})
+
+	t.Run("returns error when streamed relation count is absurdly large", func(t *testing.T) {
+		data := []byte{
+			'T',
+			0, 0, 0, 9, // xid
+			0xFF, 0xFF, 0xFF, 0xFF, // relation count
+			0, // options
+		}
+
+		msg, err := NewTruncate(data, true, relations, now)
+
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		assert.Contains(t, err.Error(), "truncate message relation IDs length must be 17179869180 byte")
+	})
+}
+
+// Zero relations is the minimum valid truncate payload and must decode.
+func TestTruncate_ZeroRelationsBoundary(t *testing.T) {
+	msg, err := NewTruncate([]byte{'T', 0, 0, 0, 0, 0}, false, map[uint32]*Relation{}, time.Now())
+
+	require.NoError(t, err)
+	assert.Empty(t, msg.RelationOIDs)
+	assert.Empty(t, msg.Relations)
 }

--- a/pq/message/format/update.go
+++ b/pq/message/format/update.go
@@ -102,7 +102,7 @@ func (m *Update) decode(data []byte, streamedTransaction bool) error {
 		if m.OldTupleData != nil {
 			for i, col := range m.NewTupleData.Columns {
 				// because toasted columns not sent until the toasted column updated
-				if col.DataType == tuple.DataTypeToast {
+				if col.DataType == tuple.DataTypeToast && i < len(m.OldTupleData.Columns) {
 					m.NewTupleData.Columns[i] = m.OldTupleData.Columns[i]
 				}
 			}

--- a/pq/message/format/update_test.go
+++ b/pq/message/format/update_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Trendyol/go-pq-cdc/pq/message/tuple"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdate_New(t *testing.T) {
@@ -92,4 +93,138 @@ func TestUpdate_New(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, msg)
+}
+
+func toastTestRelation() map[uint32]*Relation {
+	return map[uint32]*Relation{
+		16390: {
+			OID:           16390,
+			Namespace:     "public",
+			Name:          "t",
+			ColumnNumbers: 2,
+			Columns: []tuple.RelationColumn{
+				{Flags: 1, Name: "id", DataType: 23, TypeModifier: 4294967295},
+				{Flags: 0, Name: "name", DataType: 25, TypeModifier: 4294967295},
+			},
+		},
+	}
+}
+
+// A key only old tuple carries fewer columns than the new tuple. When the new
+// tuple has a toasted column at an index the old tuple does not have, the merge
+// must skip it instead of indexing past the old columns, which panicked before
+// the guard was added.
+func TestUpdate_ToastColumnBeyondOldTupleIsSkipped(t *testing.T) {
+	data := []byte{
+		'U',
+		0, 0, 64, 6, // OID 16390
+		'K',  // key typed old tuple
+		0, 1, // old tuple has a single column
+		't', 0, 0, 0, 2, '5', '3',
+		'N',
+		0, 2, // new tuple declares two columns
+		't', 0, 0, 0, 2, '5', '3',
+		'u', // toast at index 1, beyond the old tuple
+	}
+
+	msg, err := NewUpdate(data, false, toastTestRelation(), time.Now())
+
+	require.NoError(t, err)
+	require.Len(t, msg.NewTupleData.Columns, 2)
+	assert.Equal(t, tuple.DataTypeToast, msg.NewTupleData.Columns[1].DataType)
+	assert.Equal(t, map[string]any{"id": int32(53)}, msg.NewDecoded)
+	assert.Equal(t, map[string]any{"id": int32(53)}, msg.OldDecoded)
+}
+
+// When the old tuple does carry the column, a toasted new column must be replaced
+// by the old value. This pins the merge behavior itself.
+func TestUpdate_ToastColumnMergedFromOldTuple(t *testing.T) {
+	data := []byte{
+		'U',
+		0, 0, 64, 6, // OID 16390
+		'O',  // full old tuple
+		0, 2, // old tuple has both columns
+		't', 0, 0, 0, 2, '5', '3',
+		't', 0, 0, 0, 4, 'b', 'a', 'r', '2',
+		'N',
+		0, 2,
+		't', 0, 0, 0, 2, '5', '3',
+		'u', // toast at index 1, old value must be substituted
+	}
+
+	msg, err := NewUpdate(data, false, toastTestRelation(), time.Now())
+
+	require.NoError(t, err)
+	require.Len(t, msg.NewTupleData.Columns, 2)
+	assert.Equal(t, tuple.DataTypeText, msg.NewTupleData.Columns[1].DataType)
+	assert.Equal(t, []byte("bar2"), msg.NewTupleData.Columns[1].Data)
+	assert.Equal(t, map[string]any{"id": int32(53), "name": "bar2"}, msg.NewDecoded)
+}
+
+func TestUpdate_StreamedTransaction(t *testing.T) {
+	t.Run("decodes update with xid prefix", func(t *testing.T) {
+		data := []byte{
+			'U',
+			0, 0, 0, 99, // XID 99
+			0, 0, 64, 6, // OID 16390
+			'O',
+			0, 2,
+			't', 0, 0, 0, 2, '5', '3',
+			't', 0, 0, 0, 4, 'b', 'a', 'r', '2',
+			'N',
+			0, 2,
+			't', 0, 0, 0, 2, '5', '3',
+			't', 0, 0, 0, 4, 'b', 'a', 'r', '5',
+		}
+
+		msg, err := NewUpdate(data, true, toastTestRelation(), time.Now())
+
+		require.NoError(t, err)
+		assert.Equal(t, uint32(99), msg.XID)
+		assert.Equal(t, uint32(16390), msg.OID)
+		assert.Equal(t, map[string]any{"id": int32(53), "name": "bar5"}, msg.NewDecoded)
+		assert.Equal(t, map[string]any{"id": int32(53), "name": "bar2"}, msg.OldDecoded)
+	})
+
+	t.Run("returns error when streamed update is too short", func(t *testing.T) {
+		msg, err := NewUpdate([]byte{'U', 0, 0, 0, 9}, true, toastTestRelation(), time.Now())
+
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		assert.Contains(t, err.Error(), "streamed transaction update message length must be at least 11 byte, but got 5")
+	})
+}
+
+func TestUpdate_DecodeGuards(t *testing.T) {
+	t.Run("returns error when update is too short", func(t *testing.T) {
+		msg, err := NewUpdate([]byte{'U', 0, 0}, false, toastTestRelation(), time.Now())
+
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		assert.Contains(t, err.Error(), "update message length must be at least 7 byte, but got 3")
+	})
+
+	t.Run("returns error for undefined tuple type", func(t *testing.T) {
+		msg, err := NewUpdate([]byte{'U', 0, 0, 64, 6, 'X', 0}, false, toastTestRelation(), time.Now())
+
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		assert.Contains(t, err.Error(), "update message undefined tuple type")
+	})
+
+	t.Run("returns error when relation is unknown", func(t *testing.T) {
+		data := []byte{
+			'U',
+			0, 0, 64, 6,
+			'N',
+			0, 1,
+			't', 0, 0, 0, 2, '5', '3',
+		}
+
+		msg, err := NewUpdate(data, false, map[uint32]*Relation{}, time.Now())
+
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		assert.Contains(t, err.Error(), "relation not found")
+	})
 }

--- a/pq/message/message.go
+++ b/pq/message/message.go
@@ -40,6 +40,9 @@ type Type uint8
 // StreamCommit/StreamAbort messages this function returns) — it must NOT be
 // process-global, since one process may run several replication streams.
 func New(data []byte, streamedTransaction bool, serverTime time.Time, relation map[uint32]*format.Relation) (any, error) {
+	if len(data) == 0 {
+		return nil, errors.New("empty message data")
+	}
 	switch Type(data[0]) {
 	case BeginByte:
 		return format.NewBegin(data)

--- a/pq/message/message_test.go
+++ b/pq/message/message_test.go
@@ -62,3 +62,12 @@ func TestNewDecodesStreamedRelation(t *testing.T) {
 	assert.Equal(t, "id", rel.Columns[0].Name)
 	assert.Equal(t, rel, relations[16390])
 }
+
+func TestNewRejectsEmptyData(t *testing.T) {
+	for _, data := range [][]byte{{}, nil} {
+		msg, err := New(data, false, time.Now(), map[uint32]*format.Relation{})
+		require.Error(t, err)
+		assert.Nil(t, msg)
+		assert.Contains(t, err.Error(), "empty message data")
+	}
+}

--- a/pq/message/tuple/data.go
+++ b/pq/message/tuple/data.go
@@ -38,22 +38,33 @@ type RelationColumn struct {
 }
 
 func NewData(data []byte, tupleDataType uint8, skipByteLength int) (*Data, error) {
+	if skipByteLength >= len(data) {
+		return nil, errors.Newf("tuple data too short: want byte %d, have %d", skipByteLength, len(data))
+	}
 	if data[skipByteLength] != tupleDataType {
 		return nil, errors.New("invalid tuple data type: " + string(data[skipByteLength]))
 	}
 	skipByteLength++
 
 	d := &Data{}
-	d.Decode(data, skipByteLength)
+	if err := d.Decode(data, skipByteLength); err != nil {
+		return nil, err
+	}
 
 	return d, nil
 }
 
-func (d *Data) Decode(data []byte, skipByteLength int) {
+func (d *Data) Decode(data []byte, skipByteLength int) error {
+	if len(data)-skipByteLength < 2 {
+		return errors.Newf("tuple data too short for column count: want 2 bytes, have %d", len(data)-skipByteLength)
+	}
 	d.ColumnNumber = binary.BigEndian.Uint16(data[skipByteLength:])
 	skipByteLength += 2
 
 	for range d.ColumnNumber {
+		if skipByteLength >= len(data) {
+			return errors.Newf("tuple data too short for column type at byte %d, have %d", skipByteLength, len(data))
+		}
 		col := new(DataColumn)
 		col.DataType = data[skipByteLength]
 		skipByteLength++
@@ -61,10 +72,16 @@ func (d *Data) Decode(data []byte, skipByteLength int) {
 		switch col.DataType {
 		case DataTypeNull, DataTypeToast:
 		case DataTypeText, DataTypeBinary:
+			if len(data)-skipByteLength < 4 {
+				return errors.Newf("tuple data too short for column length: want 4 bytes, have %d", len(data)-skipByteLength)
+			}
 			col.Length = binary.BigEndian.Uint32(data[skipByteLength:])
 			skipByteLength += 4
 
-			col.Data = make([]byte, int(col.Length))
+			if uint64(col.Length) > uint64(len(data)-skipByteLength) {
+				return errors.Newf("tuple column length %d exceeds remaining %d bytes", col.Length, len(data)-skipByteLength)
+			}
+			col.Data = make([]byte, col.Length)
 			copy(col.Data, data[skipByteLength:])
 
 			skipByteLength += int(col.Length)
@@ -73,21 +90,25 @@ func (d *Data) Decode(data []byte, skipByteLength int) {
 		d.Columns = append(d.Columns, col)
 	}
 	d.SkipByte = skipByteLength
+	return nil
 }
 
 func (d *Data) DecodeWithColumn(columns []RelationColumn) (map[string]any, error) {
+	if len(d.Columns) > len(columns) {
+		return nil, errors.Newf("tuple has %d columns but relation defines %d", len(d.Columns), len(columns))
+	}
 	decoded := make(map[string]any, d.ColumnNumber)
 	for idx, col := range d.Columns {
-		colName := columns[idx].Name
+		relCol := columns[idx] //nolint:gosec // idx < len(d.Columns) <= len(columns), guaranteed by the guard above
 		switch col.DataType {
 		case DataTypeNull:
-			decoded[colName] = nil
+			decoded[relCol.Name] = nil
 		case DataTypeText:
-			val, err := decodeTextColumnData(col.Data, columns[idx].DataType)
+			val, err := decodeTextColumnData(col.Data, relCol.DataType)
 			if err != nil {
 				return nil, errors.Wrap(err, "decode column")
 			}
-			decoded[colName] = val
+			decoded[relCol.Name] = val
 		}
 	}
 

--- a/pq/message/tuple/data_test.go
+++ b/pq/message/tuple/data_test.go
@@ -105,3 +105,86 @@ func TestData_DecodeWithColumn(t *testing.T) {
 		assert.Equal(t, "123", decoded["unknown_col"]) // Fallback to string
 	})
 }
+
+func TestNewData_TruncatedReturnsError(t *testing.T) {
+	t.Run("text column missing length bytes", func(t *testing.T) {
+		data := []byte{DataTypeText, 0, 1, DataTypeText}
+		_, err := NewData(data, DataTypeText, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tuple data too short for column length")
+	})
+
+	t.Run("column length exceeds remaining bytes", func(t *testing.T) {
+		data := []byte{DataTypeText, 0, 1, DataTypeText, 0, 0, 0, 10, 'a', 'b'}
+		_, err := NewData(data, DataTypeText, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds remaining")
+	})
+
+	t.Run("column count exceeds available data", func(t *testing.T) {
+		data := []byte{DataTypeText, 0, 2, DataTypeNull}
+		_, err := NewData(data, DataTypeText, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tuple data too short for column type")
+	})
+
+	t.Run("skip byte past end of data", func(t *testing.T) {
+		_, err := NewData([]byte{0x00}, DataTypeText, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tuple data too short: want byte")
+	})
+}
+
+// Decode requires two bytes for the column count after the type byte. One byte
+// is the boundary the guard exists for.
+func TestData_DecodeColumnCountGuard(t *testing.T) {
+	_, err := NewData([]byte{'D', 0x00}, 'D', 0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tuple data too short for column count: want 2 bytes, have 1")
+}
+
+// Exactly two bytes after the skip is the minimum valid payload: a zero column
+// tuple. It must decode cleanly.
+func TestData_DecodeZeroColumnsBoundary(t *testing.T) {
+	d := &Data{}
+
+	err := d.Decode([]byte{0, 0}, 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, uint16(0), d.ColumnNumber)
+	assert.Equal(t, 2, d.SkipByte)
+	assert.Empty(t, d.Columns)
+}
+
+// A tuple with fewer columns than the relation defines is normal, for example a
+// key only old tuple, and must keep decoding after the over wide guard was added.
+func TestDecodeWithColumn_FewerTupleColumnsThanRelation(t *testing.T) {
+	d := &Data{
+		ColumnNumber: 1,
+		Columns: DataColumns{
+			{DataType: DataTypeText, Data: []byte("53"), Length: 2},
+		},
+	}
+
+	decoded, err := d.DecodeWithColumn([]RelationColumn{
+		{Name: "id", DataType: pgtype.Int4OID},
+		{Name: "name", DataType: pgtype.TextOID},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"id": int32(53)}, decoded)
+}
+
+func TestDecodeWithColumn_TooFewRelationColumns(t *testing.T) {
+	d := &Data{
+		ColumnNumber: 2,
+		Columns: DataColumns{
+			{DataType: DataTypeNull},
+			{DataType: DataTypeNull},
+		},
+	}
+	_, err := d.DecodeWithColumn([]RelationColumn{{Name: "id"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "relation defines")
+}

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -3,8 +3,10 @@ package replication
 import (
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	goerrors "errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -336,15 +338,57 @@ func (s *stream) sinkLoop(ctx context.Context, buf *messageBuffer, streamBuf *st
 			continue
 		}
 
-		switch copyData.Data[0] {
-		case message.PrimaryKeepaliveMessageByteID:
-			if err := s.handleKeepalive(ctx, copyData.Data[1:]); err != nil {
-				return true
-			}
-		case message.XLogDataByteID:
-			s.handleXLogData(copyData.Data[1:], buf, streamBuf)
+		if fatal := s.dispatchCopyData(ctx, copyData, buf, streamBuf); fatal {
+			return true
 		}
 	}
+}
+
+// dispatchCopyData routes a single CopyData frame to the keepalive or WAL data
+// handler. It recovers from any decode panic so that one malformed replication
+// frame is logged and skipped instead of unwinding the sink goroutine and
+// crashing the whole process, mirroring how handleXLogData already treats decode
+// errors as non fatal. A skipped frame is never delivered or acked, so the
+// confirmed flush position does not advance past it here. The recover is scoped
+// to the dispatch only, so the intentional panic in sink stays intact. A true
+// return means a genuine connection error the caller must treat as corrupted.
+func (s *stream) dispatchCopyData(ctx context.Context, copyData *pgproto3.CopyData, buf *messageBuffer, streamBuf *streamTxBuffer) (fatal bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("recovered from decode panic, skipping frame",
+				"panic", r,
+				"frame", hexPreview(copyData.Data),
+				"stack", string(debug.Stack()))
+		}
+	}()
+
+	if len(copyData.Data) == 0 {
+		logger.Warn("received empty CopyData frame, skipping")
+		return false
+	}
+
+	switch copyData.Data[0] {
+	case message.PrimaryKeepaliveMessageByteID:
+		if err := s.handleKeepalive(ctx, copyData.Data[1:]); err != nil {
+			return true
+		}
+	case message.XLogDataByteID:
+		s.handleXLogData(copyData.Data[1:], buf, streamBuf)
+	}
+	return false
+}
+
+// maxFramePreview bounds how many bytes of a frame the recovered panic log hex
+// encodes, so one oversized frame cannot produce an enormous log line.
+const maxFramePreview = 64
+
+// hexPreview hex encodes at most the first maxFramePreview bytes of data and
+// notes how many bytes were omitted.
+func hexPreview(data []byte) string {
+	if len(data) <= maxFramePreview {
+		return hex.EncodeToString(data)
+	}
+	return fmt.Sprintf("%s...(%d more bytes)", hex.EncodeToString(data[:maxFramePreview]), len(data)-maxFramePreview)
 }
 
 // extractCopyData validates a raw backend message. It returns the CopyData

--- a/pq/replication/stream_malformed_test.go
+++ b/pq/replication/stream_malformed_test.go
@@ -1,0 +1,137 @@
+package replication
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/internal/metric"
+	"github.com/Trendyol/go-pq-cdc/logger"
+	"github.com/Trendyol/go-pq-cdc/pq"
+	"github.com/Trendyol/go-pq-cdc/pq/message"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgproto3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedConn replays a fixed sequence of backend messages and then fails the
+// read, letting a test drive the real sink loop with crafted frames.
+type scriptedConn struct {
+	frames []pgproto3.BackendMessage
+}
+
+func (c *scriptedConn) ReceiveMessage(context.Context) (pgproto3.BackendMessage, error) {
+	if len(c.frames) == 0 {
+		return nil, errors.New("script exhausted")
+	}
+	next := c.frames[0]
+	c.frames = c.frames[1:]
+	return next, nil
+}
+
+func (c *scriptedConn) Connect(context.Context) error                          { return nil }
+func (c *scriptedConn) IsClosed() bool                                         { return false }
+func (c *scriptedConn) Close(context.Context) error                            { return nil }
+func (c *scriptedConn) Frontend() *pgproto3.Frontend                           { return nil }
+func (c *scriptedConn) Exec(context.Context, string) *pgconn.MultiResultReader { return nil }
+
+// panicMetric panics when the sink records CDC latency, which happens for every
+// XLogData frame before decoding. It gives the test a deterministic panic inside
+// the dispatch path so the recover backstop is exercised without depending on
+// any particular decoder bug.
+type panicMetric struct{ metric.Metric }
+
+func (panicMetric) SetCDCLatency(int64) { panic("injected decode panic") }
+
+func keepaliveFrame(walEnd uint64) *pgproto3.CopyData {
+	data := make([]byte, 18)
+	data[0] = message.PrimaryKeepaliveMessageByteID
+	binary.BigEndian.PutUint64(data[1:], walEnd)
+	// reply requested stays zero so the sink does not try to write
+	return &pgproto3.CopyData{Data: data}
+}
+
+func xLogFrame(walData ...byte) *pgproto3.CopyData {
+	frame := make([]byte, 0, 25+len(walData))
+	frame = append(frame, message.XLogDataByteID)
+	frame = append(frame, make([]byte, 24)...) // zero WAL header
+	frame = append(frame, walData...)
+	return &pgproto3.CopyData{Data: frame}
+}
+
+func newSinkTestStream(t *testing.T, conn pq.Connection) *stream {
+	t.Helper()
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+	s := NewStream("", config.Config{}, metric.NewMetric("test_slot"), func(*ListenerContext) {}).(*stream)
+	s.conn = conn
+	// The terminal read error from the exhausted script must read as a normal
+	// stop, not a corrupted connection.
+	s.closed.Store(true)
+	return s
+}
+
+// An empty CopyData frame must be skipped without touching Data[0].
+func TestDispatchCopyDataSkipsEmptyFrame(t *testing.T) {
+	s := newSinkTestStream(t, &scriptedConn{})
+
+	fatal := s.dispatchCopyData(
+		context.Background(),
+		&pgproto3.CopyData{Data: []byte{}},
+		&messageBuffer{outCh: make(chan *Message, 1)},
+		&streamTxBuffer{},
+	)
+
+	require.False(t, fatal)
+}
+
+// A panic raised while dispatching one frame must be swallowed by the recover
+// backstop, and the sink loop must go on to process the frames that follow.
+// Without the recover in dispatchCopyData this test itself dies with the
+// injected panic.
+func TestSinkLoopRecoversFromPanicAndKeepsProcessing(t *testing.T) {
+	conn := &scriptedConn{frames: []pgproto3.BackendMessage{
+		&pgproto3.CopyData{Data: []byte{}}, // empty frame, skipped by the guard
+		xLogFrame('B'),                     // reaches the metric, panics, recovered
+		keepaliveFrame(42),                 // must still be processed afterwards
+	}}
+	s := newSinkTestStream(t, conn)
+	s.metric = panicMetric{s.metric}
+
+	corrupted := s.sinkLoop(context.Background(), &messageBuffer{outCh: make(chan *Message, 16)}, &streamTxBuffer{})
+
+	require.False(t, corrupted)
+	assert.Equal(t, pq.LSN(42), s.LoadXLogPos(), "keepalive after the panic frame was not processed")
+}
+
+// Malformed replication frames of the kinds issue 152 describes must be logged
+// and skipped by the error paths alone, no recover needed, and must never end
+// the sink loop as a corrupted connection.
+func TestSinkLoopSkipsMalformedFramesWithoutPanic(t *testing.T) {
+	conn := &scriptedConn{frames: []pgproto3.BackendMessage{
+		&pgproto3.CopyData{Data: []byte{message.XLogDataByteID, 1, 2, 3}}, // truncated WAL header
+		xLogFrame('B', 0, 0, 0),                                          // truncated begin body
+		xLogFrame('R', 0, 0, 0, 1, 'a', 0, 'b', 0),                       // relation cut before replica identity
+		xLogFrame('U', 0, 0, 64, 6, 'N', 0, 2, 't', 0, 0, 0, 99),         // update column length past the end
+		keepaliveFrame(42),                                               // must still be processed afterwards
+	}}
+	s := newSinkTestStream(t, conn)
+
+	corrupted := s.sinkLoop(context.Background(), &messageBuffer{outCh: make(chan *Message, 16)}, &streamTxBuffer{})
+
+	require.False(t, corrupted)
+	assert.Equal(t, pq.LSN(42), s.LoadXLogPos(), "keepalive after the malformed frames was not processed")
+}
+
+// The recovered panic log must stay bounded: a small frame is encoded whole, a
+// large frame is truncated and annotated with the omitted byte count.
+func TestHexPreviewTruncatesLargeFrames(t *testing.T) {
+	assert.Equal(t, "010203", hexPreview([]byte{1, 2, 3}))
+
+	preview := hexPreview(make([]byte, maxFramePreview+10))
+	assert.Contains(t, preview, "more bytes")
+	assert.LessOrEqual(t, len(preview), 2*maxFramePreview+32)
+}


### PR DESCRIPTION
## Summary

A single malformed or truncated pgoutput frame can currently panic a decoder. The sink goroutine has no recover, so the panic unwinds and takes the whole process down instead of hitting the log and skip path that `handleXLogData` already uses for decode errors. This PR makes every decode path return an error on bad input and adds a recover backstop in the sink goroutine, so one bad frame is logged and skipped rather than fatal.

This is a complete standalone fix from `main`. It takes the same approach as #153 for the files they both touch, and additionally closes the panic sites #153 does not cover (`relation.go`, `DecodeWithColumn`, the empty CopyData frame, the 32 bit allocation caps, and the missing recover backstop), so it can land in place of #153.

Fixes #152

## Changes

* `message.New` rejects empty data instead of indexing `data[0]`.
* `tuple.Data.Decode` bounds checks the column count, the per column type byte, the length field and the data copy, and caps the wire declared length against the remaining bytes with an unsigned comparison so a 32 bit build cannot allocate a negative length slice.
* `tuple.Data.DecodeWithColumn` rejects a tuple that declares more columns than the relation defines.
* `relation.decode` bounds checks the replica identity byte, the column count and every per column field (the column loop is extracted into a helper).
* The update TOAST merge no longer indexes the old tuple past its length.
* `begin` and `commit` minimum length guards were off by one (20 should be 21, 25 should be 26). The existing boundary tests already document 21 and 26 as the true minimums.
* `truncate` validates the relation count with a width safe comparison.
* The sink goroutine recovers from any decode panic, logs the offending frame, and skips it without advancing the confirmed flush position. The intentional corrupted connection panic is left untouched.

## Verification

`go build ./...`, `go vet ./...` and `go test ./pq/...` all pass, and `golangci-lint` v2.11.4 (the pinned version) plus `fieldalignment` report no new issues.

Every previously panicking frame now returns an error through `message.New` rather than panicking. A truncated relation frame returns `relation message missing replica identity`, and an insert whose tuple declares more columns than the cached relation returns `tuple has 2 columns but relation defines 1`. Well formed begin (21 bytes) and commit (26 bytes) frames still decode with no error. Tests are added for every guard.

