### PR TITLE
fix: skip SetReplicaIdentities when CreateIfNotExists is false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
+.claude
 vendor

--- a/connector.go
+++ b/connector.go
@@ -211,17 +211,21 @@ func initializeTimescaleDB(ctx context.Context, cfg config.Config) (*timescaledb
 
 // initializePublication sets up and creates the publication.
 //
-// Replica identity DDL (SetReplicaIdentities) is gated on CreateIfNotExists so that
-// createIfNotExists: false consistently means "the connector manages no DDL" across
-// the publication, the slot, and replica identity. This allows least-privilege CDC
-// roles (SELECT + REPLICATION, no table ownership / ALTER) to start the connector
-// against a publication and slot that are provisioned out-of-band. When
-// CreateIfNotExists is true the connector applies configured replica identities as
-// before. See https://github.com/Trendyol/go-pq-cdc/issues/158 for the rationale.
+// Replica identity is validated or applied depending on CreateIfNotExists:
+// - When CreateIfNotExists is true: SetReplicaIdentities applies configured identities.
+// - When CreateIfNotExists is false: ValidateReplicaIdentities checks that existing
+//   identities match the configuration, without requiring ALTER TABLE permission.
+//
+// This allows least-privilege CDC roles (SELECT + REPLICATION, no table ownership)
+// to work with pre-provisioned publications and replicas. See #158 for rationale.
 func initializePublication(ctx context.Context, cfg config.Config, conn pq.Connection) (*publication.Config, error) {
 	pub := publication.New(cfg.Publication, conn)
 	if cfg.Publication.CreateIfNotExists {
 		if err := pub.SetReplicaIdentities(ctx); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := pub.ValidateReplicaIdentities(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/connector.go
+++ b/connector.go
@@ -209,11 +209,21 @@ func initializeTimescaleDB(ctx context.Context, cfg config.Config) (*timescaledb
 	return tdb, nil
 }
 
-// initializePublication sets up and creates the publication
+// initializePublication sets up and creates the publication.
+//
+// Replica identity DDL (SetReplicaIdentities) is gated on CreateIfNotExists so that
+// createIfNotExists: false consistently means "the connector manages no DDL" across
+// the publication, the slot, and replica identity. This allows least-privilege CDC
+// roles (SELECT + REPLICATION, no table ownership / ALTER) to start the connector
+// against a publication and slot that are provisioned out-of-band. When
+// CreateIfNotExists is true the connector applies configured replica identities as
+// before. See https://github.com/Trendyol/go-pq-cdc/issues/158 for the rationale.
 func initializePublication(ctx context.Context, cfg config.Config, conn pq.Connection) (*publication.Config, error) {
 	pub := publication.New(cfg.Publication, conn)
-	if err := pub.SetReplicaIdentities(ctx); err != nil {
-		return nil, err
+	if cfg.Publication.CreateIfNotExists {
+		if err := pub.SetReplicaIdentities(ctx); err != nil {
+			return nil, err
+		}
 	}
 	return pub.Create(ctx)
 }
@@ -632,7 +642,7 @@ func (c *connector) CaptureSlot(ctx context.Context) {
 	logger.Info("slot capturing...")
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
-	for range ticker.C {
+	for range ticker {
 		info, err := c.slot.Info(ctx)
 		if err != nil {
 			if goerrors.Is(err, slot.ErrorSlotClosed) {

--- a/connector.go
+++ b/connector.go
@@ -211,23 +211,19 @@ func initializeTimescaleDB(ctx context.Context, cfg config.Config) (*timescaledb
 
 // initializePublication sets up and creates the publication.
 //
-// Replica identity is validated or applied depending on CreateIfNotExists:
-// - When CreateIfNotExists is true: SetReplicaIdentities applies configured identities.
-// - When CreateIfNotExists is false: ValidateReplicaIdentities checks that existing
-//   identities match the configuration, without requiring ALTER TABLE permission.
-//
-// This allows least-privilege CDC roles (SELECT + REPLICATION, no table ownership)
-// to work with pre-provisioned publications and replicas. See #158 for rationale.
+// Replica identity is applied or checked depending on CreateIfNotExists:
+// - When CreateIfNotExists is true: ApplyReplicaIdentities may ALTER TABLE.
+// - When CreateIfNotExists is false: CheckReplicaIdentities is read-only; any
+//   failure is logged as Error with a manual-action hint and does not stop startup.
+//   See #158 for rationale.
 func initializePublication(ctx context.Context, cfg config.Config, conn pq.Connection) (*publication.Config, error) {
 	pub := publication.New(cfg.Publication, conn)
 	if cfg.Publication.CreateIfNotExists {
-		if err := pub.SetReplicaIdentities(ctx); err != nil {
+		if err := pub.ApplyReplicaIdentities(ctx); err != nil {
 			return nil, err
 		}
-	} else {
-		if err := pub.ValidateReplicaIdentities(ctx); err != nil {
-			return nil, err
-		}
+	} else if err := pub.CheckReplicaIdentities(ctx); err != nil {
+		logger.Error("replica identity check failed; take manual action to ALTER TABLE ... REPLICA IDENTITY to match the config", "error", err)
 	}
 	return pub.Create(ctx)
 }

--- a/connector.go
+++ b/connector.go
@@ -642,7 +642,7 @@ func (c *connector) CaptureSlot(ctx context.Context) {
 	logger.Info("slot capturing...")
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
-	for range ticker {
+	for range ticker.C {
 		info, err := c.slot.Info(ctx)
 		if err != nil {
 			if goerrors.Is(err, slot.ErrorSlotClosed) {

--- a/integration_test/system_identity_full_test.go
+++ b/integration_test/system_identity_full_test.go
@@ -349,7 +349,7 @@ func TestReplicaIdentityUsingIndexMissingIndexReturnsError(t *testing.T) {
 	})
 }
 
-func TestReplicaIdentityAppliedWhenCreateIfNotExistsFalse(t *testing.T) {
+func TestReplicaIdentityNotAppliedWhenCreateIfNotExistsFalse(t *testing.T) {
 	ctx := context.Background()
 
 	cdcCfg := cloneConnectorConfig()
@@ -394,8 +394,11 @@ func TestReplicaIdentityAppliedWhenCreateIfNotExistsFalse(t *testing.T) {
 			assert.NoError(t, postgresConn.Close(ctx))
 		})
 
+		// CreateIfNotExists is false, so the connector must not issue
+		// ALTER TABLE ... REPLICA IDENTITY: books stays at DEFAULT even
+		// though the config asks for FULL.
 		identity, _ = getReplicaIdentity(ctx, t, postgresConn, "public", "books")
-		assert.Equal(t, publication.ReplicaIdentityFull, identity)
+		assert.Equal(t, publication.ReplicaIdentityDefault, identity)
 	})
 }
 

--- a/integration_test/system_identity_full_test.go
+++ b/integration_test/system_identity_full_test.go
@@ -402,6 +402,51 @@ func TestReplicaIdentityNotAppliedWhenCreateIfNotExistsFalse(t *testing.T) {
 	})
 }
 
+func TestReplicaIdentityAppliedWhenCreateIfNotExistsTrue(t *testing.T) {
+	ctx := context.Background()
+
+	cdcCfg := cloneConnectorConfig()
+	cdcCfg.Slot.Name = "slot_test_replica_identity_create_true"
+	cdcCfg.Publication.CreateIfNotExists = true
+	cdcCfg.Publication.Tables[0].ReplicaIdentity = publication.ReplicaIdentityFull
+
+	forEachProtoVersion(t, cdcCfg, func(t *testing.T, cdcCfg config.Config) {
+		postgresConn, err := newPostgresConn()
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		if !assert.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg)) {
+			t.FailNow()
+		}
+
+		// books starts at DEFAULT (no ALTER applied yet); the connector
+		// creates the publication itself since CreateIfNotExists is true.
+		identity, _ := getReplicaIdentity(ctx, t, postgresConn, "public", "books")
+		require.Equal(t, publication.ReplicaIdentityDefault, identity)
+
+		handlerFunc := func(ctx *replication.ListenerContext) {
+			_ = ctx.Ack()
+		}
+
+		_, err = cdc.NewConnector(ctx, cdcCfg, handlerFunc)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		t.Cleanup(func() {
+			assert.NoError(t, RestoreDB(ctx))
+			assert.NoError(t, pgExec(ctx, postgresConn, "DROP PUBLICATION IF EXISTS "+cdcCfg.Publication.Name))
+			assert.NoError(t, postgresConn.Close(ctx))
+		})
+
+		// CreateIfNotExists is true, so the connector applies the configured
+		// replica identity: books is altered from DEFAULT to FULL.
+		identity, _ = getReplicaIdentity(ctx, t, postgresConn, "public", "books")
+		assert.Equal(t, publication.ReplicaIdentityFull, identity)
+	})
+}
+
 func getReplicaIdentity(ctx context.Context, t *testing.T, conn pq.Connection, schema, table string) (string, string) {
 	t.Helper()
 

--- a/integration_test/system_identity_full_test.go
+++ b/integration_test/system_identity_full_test.go
@@ -349,7 +349,7 @@ func TestReplicaIdentityUsingIndexMissingIndexReturnsError(t *testing.T) {
 	})
 }
 
-func TestReplicaIdentityMismatchDetectedWhenCreateIfNotExistsFalse(t *testing.T) {
+func TestReplicaIdentityMismatchLoggedWhenCreateIfNotExistsFalse(t *testing.T) {
 	ctx := context.Background()
 
 	cdcCfg := cloneConnectorConfig()
@@ -383,10 +383,10 @@ func TestReplicaIdentityMismatchDetectedWhenCreateIfNotExistsFalse(t *testing.T)
 			_ = ctx.Ack()
 		}
 
-		// Connector should fail because replica identity doesn't match config.
+		// Connector should start; mismatch is logged, not fatal.
 		_, err = cdc.NewConnector(ctx, cdcCfg, handlerFunc)
-		if assert.Error(t, err) {
-			assert.ErrorContains(t, err, "replica identity mismatch")
+		if !assert.NoError(t, err) {
+			t.FailNow()
 		}
 
 		t.Cleanup(func() {
@@ -394,10 +394,14 @@ func TestReplicaIdentityMismatchDetectedWhenCreateIfNotExistsFalse(t *testing.T)
 			assert.NoError(t, pgExec(ctx, postgresConn, "DROP PUBLICATION IF EXISTS "+cdcCfg.Publication.Name))
 			assert.NoError(t, postgresConn.Close(ctx))
 		})
+
+		// Identity left untouched (no ALTER TABLE).
+		identity, _ = getReplicaIdentity(ctx, t, postgresConn, "public", "books")
+		assert.Equal(t, publication.ReplicaIdentityDefault, identity)
 	})
 }
 
-func TestReplicaIdentityValidationSucceedsWhenCreateIfNotExistsFalse(t *testing.T) {
+func TestReplicaIdentityCheckSucceedsWhenCreateIfNotExistsFalse(t *testing.T) {
 	ctx := context.Background()
 
 	cdcCfg := cloneConnectorConfig()

--- a/integration_test/system_identity_full_test.go
+++ b/integration_test/system_identity_full_test.go
@@ -394,9 +394,7 @@ func TestReplicaIdentityNotAppliedWhenCreateIfNotExistsFalse(t *testing.T) {
 			assert.NoError(t, postgresConn.Close(ctx))
 		})
 
-		// CreateIfNotExists is false, so the connector must not issue
-		// ALTER TABLE ... REPLICA IDENTITY: books stays at DEFAULT even
-		// though the config asks for FULL.
+		// no ALTER issued: books stays at DEFAULT.
 		identity, _ = getReplicaIdentity(ctx, t, postgresConn, "public", "books")
 		assert.Equal(t, publication.ReplicaIdentityDefault, identity)
 	})
@@ -420,8 +418,7 @@ func TestReplicaIdentityAppliedWhenCreateIfNotExistsTrue(t *testing.T) {
 			t.FailNow()
 		}
 
-		// books starts at DEFAULT (no ALTER applied yet); the connector
-		// creates the publication itself since CreateIfNotExists is true.
+		// connector creates the publication itself.
 		identity, _ := getReplicaIdentity(ctx, t, postgresConn, "public", "books")
 		require.Equal(t, publication.ReplicaIdentityDefault, identity)
 
@@ -440,8 +437,7 @@ func TestReplicaIdentityAppliedWhenCreateIfNotExistsTrue(t *testing.T) {
 			assert.NoError(t, postgresConn.Close(ctx))
 		})
 
-		// CreateIfNotExists is true, so the connector applies the configured
-		// replica identity: books is altered from DEFAULT to FULL.
+		// altered to FULL.
 		identity, _ = getReplicaIdentity(ctx, t, postgresConn, "public", "books")
 		assert.Equal(t, publication.ReplicaIdentityFull, identity)
 	})

--- a/integration_test/system_identity_full_test.go
+++ b/integration_test/system_identity_full_test.go
@@ -349,11 +349,11 @@ func TestReplicaIdentityUsingIndexMissingIndexReturnsError(t *testing.T) {
 	})
 }
 
-func TestReplicaIdentityNotAppliedWhenCreateIfNotExistsFalse(t *testing.T) {
+func TestReplicaIdentityMismatchDetectedWhenCreateIfNotExistsFalse(t *testing.T) {
 	ctx := context.Background()
 
 	cdcCfg := cloneConnectorConfig()
-	cdcCfg.Slot.Name = "slot_test_replica_identity_create_false"
+	cdcCfg.Slot.Name = "slot_test_replica_identity_mismatch"
 	cdcCfg.Publication.CreateIfNotExists = false
 	cdcCfg.Publication.Tables[0].ReplicaIdentity = publication.ReplicaIdentityFull
 
@@ -375,7 +375,7 @@ func TestReplicaIdentityNotAppliedWhenCreateIfNotExistsFalse(t *testing.T) {
 			t.FailNow()
 		}
 
-		// books starts at DEFAULT (no ALTER applied yet).
+		// books starts at DEFAULT (mismatch: config wants FULL).
 		identity, _ := getReplicaIdentity(ctx, t, postgresConn, "public", "books")
 		require.Equal(t, publication.ReplicaIdentityDefault, identity)
 
@@ -383,6 +383,57 @@ func TestReplicaIdentityNotAppliedWhenCreateIfNotExistsFalse(t *testing.T) {
 			_ = ctx.Ack()
 		}
 
+		// Connector should fail because replica identity doesn't match config.
+		_, err = cdc.NewConnector(ctx, cdcCfg, handlerFunc)
+		if assert.Error(t, err) {
+			assert.ErrorContains(t, err, "replica identity mismatch")
+		}
+
+		t.Cleanup(func() {
+			assert.NoError(t, RestoreDB(ctx))
+			assert.NoError(t, pgExec(ctx, postgresConn, "DROP PUBLICATION IF EXISTS "+cdcCfg.Publication.Name))
+			assert.NoError(t, postgresConn.Close(ctx))
+		})
+	})
+}
+
+func TestReplicaIdentityValidationSucceedsWhenCreateIfNotExistsFalse(t *testing.T) {
+	ctx := context.Background()
+
+	cdcCfg := cloneConnectorConfig()
+	cdcCfg.Slot.Name = "slot_test_replica_identity_validation_success"
+	cdcCfg.Publication.CreateIfNotExists = false
+	cdcCfg.Publication.Tables[0].ReplicaIdentity = publication.ReplicaIdentityFull
+
+	forEachProtoVersion(t, cdcCfg, func(t *testing.T, cdcCfg config.Config) {
+		postgresConn, err := newPostgresConn()
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		if !assert.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg)) {
+			t.FailNow()
+		}
+
+		// Publication must pre-exist.
+		err = pgExec(ctx, postgresConn, fmt.Sprintf(
+			"CREATE PUBLICATION %s FOR TABLE books WITH (publish = 'insert, update, delete');",
+			cdcCfg.Publication.Name))
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// Pre-configure books to FULL to match the config.
+		err = pgExec(ctx, postgresConn, "ALTER TABLE books REPLICA IDENTITY FULL;")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		handlerFunc := func(ctx *replication.ListenerContext) {
+			_ = ctx.Ack()
+		}
+
+		// Connector should start successfully (validation passes).
 		_, err = cdc.NewConnector(ctx, cdcCfg, handlerFunc)
 		if !assert.NoError(t, err) {
 			t.FailNow()
@@ -394,9 +445,9 @@ func TestReplicaIdentityNotAppliedWhenCreateIfNotExistsFalse(t *testing.T) {
 			assert.NoError(t, postgresConn.Close(ctx))
 		})
 
-		// no ALTER issued: books stays at DEFAULT.
-		identity, _ = getReplicaIdentity(ctx, t, postgresConn, "public", "books")
-		assert.Equal(t, publication.ReplicaIdentityDefault, identity)
+		// Confirm books stayed at FULL (no ALTER issued by connector).
+		identity, _ := getReplicaIdentity(ctx, t, postgresConn, "public", "books")
+		assert.Equal(t, publication.ReplicaIdentityFull, identity)
 	})
 }
 

--- a/pq/publication/replica_identity.go
+++ b/pq/publication/replica_identity.go
@@ -57,6 +57,52 @@ func (c *Publication) SetReplicaIdentities(ctx context.Context) error {
 	return nil
 }
 
+func (c *Publication) ValidateReplicaIdentities(ctx context.Context) error {
+	configured := make(Tables, 0, len(c.cfg.Tables))
+	for _, t := range c.cfg.Tables {
+		if t.ReplicaIdentity != "" {
+			configured = append(configured, t)
+		}
+	}
+	if len(configured) == 0 {
+		return nil
+	}
+
+	c.warnNothingReplicaIdentityWithUpdateDelete()
+
+	tables, err := c.GetReplicaIdentities(ctx)
+	if err != nil {
+		return err
+	}
+
+	mismatches := configured.Diff(tables)
+	if len(mismatches) > 0 {
+		var details strings.Builder
+		for i, mismatch := range mismatches {
+			if i > 0 {
+				details.WriteString("; ")
+			}
+			details.WriteString(fmt.Sprintf("%s.%s: configured=%s, actual=%s",
+				mismatch.Schema, mismatch.Name, mismatch.ReplicaIdentity, c.findActualIdentity(tables, mismatch)))
+		}
+		return fmt.Errorf("replica identity mismatch: %s", details.String())
+	}
+
+	return nil
+}
+
+func (c *Publication) findActualIdentity(tables []Table, configured Table) string {
+	for _, t := range tables {
+		if t.Schema == configured.Schema && t.Name == configured.Name {
+			if t.ReplicaIdentity == "" {
+				return ReplicaIdentityDefault
+			}
+			return t.ReplicaIdentity
+		}
+	}
+	return "unknown"
+}
+
 func (c *Publication) warnNothingReplicaIdentityWithUpdateDelete() {
 	hasUpdateDelete := c.cfg.Operations.Contains(OperationUpdate) || c.cfg.Operations.Contains(OperationDelete)
 	if !hasUpdateDelete {

--- a/pq/publication/replica_identity.go
+++ b/pq/publication/replica_identity.go
@@ -30,34 +30,40 @@ var (
 	}
 )
 
-func (c *Publication) SetReplicaIdentities(ctx context.Context) error {
-	configured := make(Tables, 0, len(c.cfg.Tables))
-	for _, t := range c.cfg.Tables {
-		if t.ReplicaIdentity != "" {
-			configured = append(configured, t)
-		}
-	}
-	if len(configured) == 0 {
-		return nil
-	}
-
-	c.warnNothingReplicaIdentityWithUpdateDelete()
-
-	tables, err := c.GetReplicaIdentities(ctx)
+func (c *Publication) ApplyReplicaIdentities(ctx context.Context) error {
+	mismatches, _, err := c.replicaIdentityMismatches(ctx)
 	if err != nil {
 		return err
 	}
-
-	for _, d := range configured.Diff(tables) {
+	for _, d := range mismatches {
 		if err = c.AlterTableReplicaIdentity(ctx, d); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
-func (c *Publication) ValidateReplicaIdentities(ctx context.Context) error {
+func (c *Publication) CheckReplicaIdentities(ctx context.Context) error {
+	mismatches, actual, err := c.replicaIdentityMismatches(ctx)
+	if err != nil {
+		return err
+	}
+	if len(mismatches) == 0 {
+		return nil
+	}
+
+	var details strings.Builder
+	for i, mismatch := range mismatches {
+		if i > 0 {
+			details.WriteString("; ")
+		}
+		details.WriteString(fmt.Sprintf("%s.%s: configured=%s, actual=%s",
+			mismatch.Schema, mismatch.Name, formatReplicaIdentity(mismatch), findActualIdentity(actual, mismatch)))
+	}
+	return fmt.Errorf("replica identity mismatch: %s", details.String())
+}
+
+func (c *Publication) replicaIdentityMismatches(ctx context.Context) (Tables, []Table, error) {
 	configured := make(Tables, 0, len(c.cfg.Tables))
 	for _, t := range c.cfg.Tables {
 		if t.ReplicaIdentity != "" {
@@ -65,42 +71,52 @@ func (c *Publication) ValidateReplicaIdentities(ctx context.Context) error {
 		}
 	}
 	if len(configured) == 0 {
-		return nil
+		return nil, nil, nil
 	}
 
 	c.warnNothingReplicaIdentityWithUpdateDelete()
 
-	tables, err := c.GetReplicaIdentities(ctx)
+	actual, err := c.GetReplicaIdentities(ctx)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
-	mismatches := configured.Diff(tables)
-	if len(mismatches) > 0 {
-		var details strings.Builder
-		for i, mismatch := range mismatches {
-			if i > 0 {
-				details.WriteString("; ")
-			}
-			details.WriteString(fmt.Sprintf("%s.%s: configured=%s, actual=%s",
-				mismatch.Schema, mismatch.Name, mismatch.ReplicaIdentity, c.findActualIdentity(tables, mismatch)))
-		}
-		return fmt.Errorf("replica identity mismatch: %s", details.String())
-	}
-
-	return nil
+	return identityOnlyTables(configured).Diff(actual), actual, nil
 }
 
-func (c *Publication) findActualIdentity(tables []Table, configured Table) string {
+// identityOnlyTables keeps only fields used for replica-identity comparison so
+// Diff does not treat publication Columns/Partitioned as identity mismatches.
+func identityOnlyTables(tables Tables) Tables {
+	out := make(Tables, len(tables))
+	for i, t := range tables {
+		out[i] = Table{
+			Schema:               t.Schema,
+			Name:                 t.Name,
+			ReplicaIdentity:      t.ReplicaIdentity,
+			ReplicaIdentityIndex: t.ReplicaIdentityIndex,
+		}
+	}
+	return out
+}
+
+func findActualIdentity(tables []Table, configured Table) string {
 	for _, t := range tables {
 		if t.Schema == configured.Schema && t.Name == configured.Name {
-			if t.ReplicaIdentity == "" {
-				return ReplicaIdentityDefault
-			}
-			return t.ReplicaIdentity
+			return formatReplicaIdentity(t)
 		}
 	}
 	return "unknown"
+}
+
+func formatReplicaIdentity(t Table) string {
+	identity := t.ReplicaIdentity
+	if identity == "" {
+		identity = ReplicaIdentityDefault
+	}
+	if identity == ReplicaIdentityUsingIndex && t.ReplicaIdentityIndex != "" {
+		return fmt.Sprintf("%s %s", identity, t.ReplicaIdentityIndex)
+	}
+	return identity
 }
 
 func (c *Publication) warnNothingReplicaIdentityWithUpdateDelete() {
@@ -111,7 +127,7 @@ func (c *Publication) warnNothingReplicaIdentityWithUpdateDelete() {
 
 	for _, table := range c.cfg.Tables {
 		if table.ReplicaIdentity == ReplicaIdentityNothing {
-			logger.Warn(
+			logger.Error(
 				"table uses REPLICA IDENTITY NOTHING with UPDATE/DELETE publication operations",
 				"table", qualifiedTableName(table),
 				"note", "NOTHING is typically suitable for insert-only scenarios",

--- a/pq/publication/replica_identity_test.go
+++ b/pq/publication/replica_identity_test.go
@@ -4,7 +4,57 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestIdentityOnlyTables(t *testing.T) {
+	t.Run("should ignore columns and partitioned so Diff matches on identity only", func(t *testing.T) {
+		configured := Tables{
+			{
+				Name:            "books",
+				Schema:          "public",
+				ReplicaIdentity: ReplicaIdentityFull,
+				Columns:         []string{"id", "name"},
+				Partitioned:     true,
+			},
+		}
+		actual := Tables{
+			{
+				Name:            "books",
+				Schema:          "public",
+				ReplicaIdentity: ReplicaIdentityFull,
+			},
+		}
+
+		require.NotEmpty(t, configured.Diff(actual), "Diff includes Columns/Partitioned by design")
+
+		diff := identityOnlyTables(configured).Diff(actual)
+		assert.Empty(t, diff)
+	})
+
+	t.Run("should still detect replica identity mismatches", func(t *testing.T) {
+		configured := Tables{
+			{
+				Name:            "books",
+				Schema:          "public",
+				ReplicaIdentity: ReplicaIdentityFull,
+				Columns:         []string{"id"},
+			},
+		}
+		actual := Tables{
+			{
+				Name:            "books",
+				Schema:          "public",
+				ReplicaIdentity: ReplicaIdentityDefault,
+			},
+		}
+
+		diff := identityOnlyTables(configured).Diff(actual)
+		require.Len(t, diff, 1)
+		assert.Equal(t, ReplicaIdentityFull, diff[0].ReplicaIdentity)
+		assert.Empty(t, diff[0].Columns)
+	})
+}
 
 func TestMapReplicaIdentity(t *testing.T) {
 	t.Run("should map postgres relreplident codes", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Gate `Publication.SetReplicaIdentities` on `CreateIfNotExists`, matching the gate `Publication.Create` and `Slot.Create` already apply. `createIfNotExists: false` now consistently means "the connector manages no DDL" across publication, slot, and replica identity.

Fixes #158 — full context, the production error, and the current-vs-proposed code are there.

## Tests

- `TestReplicaIdentityNotAppliedWhenCreateIfNotExistsFalse` — updated: replica identity stays at DEFAULT when `createIfNotExists: false`.
- `TestReplicaIdentityAppliedWhenCreateIfNotExistsTrue` — new: replica identity is still applied when `createIfNotExists: true`.

## Note

Re-introduces the gate #145 removed (to fix a silent-data-loss bug). Trade-off discussed in #158; open to an independent `applyReplicaIdentity` flag instead if maintainers prefer.