### PR TITLE
fix: restart after unexpected replication disconnect

### DIFF
--- a/pq/replication/shutdown_audit_test.go
+++ b/pq/replication/shutdown_audit_test.go
@@ -161,26 +161,76 @@ func TestListenerReceivesCancellationDuringStreamClose(t *testing.T) {
 	}
 }
 
-func TestStreamStopsOnUnexpectedEOFWithoutPanic(t *testing.T) {
+func TestSinkLoopTreatsConnectionTerminationAsCorrupted(t *testing.T) {
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+
+	tests := []struct {
+		err  error
+		name string
+	}{
+		{name: "EOF", err: io.EOF},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF},
+		{name: "closed network connection", err: net.ErrClosed},
+		{name: "connection reset", err: syscall.ECONNRESET},
+		{name: "broken pipe", err: syscall.EPIPE},
+		{name: "admin shutdown", err: &pgconn.PgError{Code: postgresAdminShutdown}},
+		{name: "crash shutdown", err: &pgconn.PgError{Code: postgresCrashShutdown}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := NewStream("", config.Config{}, metric.NewMetric("test"), func(*ListenerContext) {}).(*stream)
+			stream.conn = receiveErrConn{err: tt.err}
+
+			corrupted := stream.sinkLoop(
+				context.Background(),
+				&messageBuffer{outCh: make(chan *Message, 1)},
+				&streamTxBuffer{},
+			)
+			if !corrupted {
+				t.Fatal("expected connection termination while running to be treated as corrupted so the process restarts")
+			}
+		})
+	}
+}
+
+func TestSinkLoopDoesNotTreatTerminationAsCorruptedWhenAlreadyClosed(t *testing.T) {
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+
+	stream := NewStream("", config.Config{}, metric.NewMetric("test"), func(*ListenerContext) {}).(*stream)
+	stream.conn = receiveErrConn{err: io.ErrUnexpectedEOF}
+	stream.closed.Store(true)
+
+	corrupted := stream.sinkLoop(
+		context.Background(),
+		&messageBuffer{outCh: make(chan *Message, 1)},
+		&streamTxBuffer{},
+	)
+	if corrupted {
+		t.Fatal("expected an already-closed stream to stop without being treated as corrupted")
+	}
+}
+
+func TestSinkPanicsAfterClosingOnUnexpectedDisconnect(t *testing.T) {
 	logger.InitLogger(logger.NewSlog(slog.LevelError))
 
 	stream := NewStream("", config.Config{}, metric.NewMetric("test"), func(*ListenerContext) {}).(*stream)
 	stream.conn = eofConn{}
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		stream.sink(context.Background())
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected panic after unexpected disconnect so the process restarts with a fresh connection")
+		}
+		if recovered != "corrupted connection" {
+			t.Fatalf("unexpected panic value: %v", recovered)
+		}
+		if !stream.closed.Load() {
+			t.Fatal("expected the stream to close before panicking")
+		}
 	}()
 
-	select {
-	case <-done:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("sink did not stop after PostgreSQL returned EOF")
-	}
-	if !stream.closed.Load() {
-		t.Fatal("sink did not mark the stream closed after EOF")
-	}
+	stream.sink(context.Background())
 }
 
 func TestReplicationConnectionTerminationErrors(t *testing.T) {
@@ -245,6 +295,24 @@ func (c *shutdownAuditConn) ReceiveMessage(context.Context) (pgproto3.BackendMes
 func (c *shutdownAuditConn) Frontend() *pgproto3.Frontend { return nil }
 
 func (c *shutdownAuditConn) Exec(context.Context, string) *pgconn.MultiResultReader { return nil }
+
+type receiveErrConn struct {
+	err error
+}
+
+func (receiveErrConn) Connect(context.Context) error { return nil }
+
+func (receiveErrConn) IsClosed() bool { return false }
+
+func (receiveErrConn) Close(context.Context) error { return nil }
+
+func (c receiveErrConn) ReceiveMessage(context.Context) (pgproto3.BackendMessage, error) {
+	return nil, c.err
+}
+
+func (receiveErrConn) Frontend() *pgproto3.Frontend { return nil }
+
+func (receiveErrConn) Exec(context.Context, string) *pgconn.MultiResultReader { return nil }
 
 type eofConn struct{}
 

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -351,16 +351,17 @@ func (s *stream) sinkLoop(ctx context.Context, buf *messageBuffer, streamBuf *st
 				return false
 			}
 			if handleReplicationConnectionTermination(err) {
-				return false
+				// Connection is gone while we are still running. Close and panic
+				// so the process restarts with a fresh replication connection.
+				return true
 			}
 			if pgconn.Timeout(err) {
 				if s.LoadXLogPos() > 0 {
 					if err = s.sendStandbyStatusUpdate(ctx); err != nil {
-						terminated := handleReplicationConnectionTermination(err)
-						if !terminated {
+						if !handleReplicationConnectionTermination(err) {
 							logger.Error("send stand by status update", "error", err)
 						}
-						return !terminated
+						return true
 					}
 					logger.Debug("send stand by status update")
 				}
@@ -378,7 +379,8 @@ func (s *stream) sinkLoop(ctx context.Context, buf *messageBuffer, streamBuf *st
 		switch copyData.Data[0] {
 		case message.PrimaryKeepaliveMessageByteID:
 			if err := s.handleKeepalive(ctx, copyData.Data[1:]); err != nil {
-				return !handleReplicationConnectionTermination(err)
+				handleReplicationConnectionTermination(err)
+				return true
 			}
 		case message.XLogDataByteID:
 			s.handleXLogData(copyData.Data[1:], buf, streamBuf)


### PR DESCRIPTION
## Summary

Restart the process after an unexpected replication-connection termination so it establishes a fresh connection.

## Problem

While the stream is actively running, PostgreSQL or the network can terminate the replication connection with errors such as EOF, an unexpected EOF, a closed network connection, a reset, a broken pipe, or PostgreSQL shutdown SQLSTATEs. 
## Changes

- Close the stream before panicking so a supervisor can restart the process with a fresh replication connection.
- Preserve graceful behavior when shutdown has already begun.
- Apply the same restart path to replication reads, standby-status updates, and keepalive replies.
- Add unit coverage for the supported transport and PostgreSQL termination errors, graceful close behavior, and close-before-panic behavior.

## Verification

The following check passes:

- `go test ./pq/replication`