### PR TITLE
fix(snapshot): apply filters to integer range bounds

### DIFF
--- a/pq/snapshot/coordinator.go
+++ b/pq/snapshot/coordinator.go
@@ -1026,10 +1026,7 @@ func isIntegerType(dataType string) bool {
 }
 
 func (s *Snapshotter) getPrimaryKeyBoundsWithConn(ctx context.Context, conn pq.Connection, table publication.Table, pkColumn string) (int64, int64, bool, error) {
-	query := fmt.Sprintf(`
-		SELECT MIN(%s)::bigint AS min_value, MAX(%s)::bigint AS max_value
-		FROM %s.%s
-	`, pkColumn, pkColumn, table.Schema, table.Name)
+	query := s.buildPrimaryKeyBoundsQuery(table, pkColumn)
 
 	results, err := s.execQuery(ctx, conn, query)
 	if err != nil {
@@ -1056,6 +1053,17 @@ func (s *Snapshotter) getPrimaryKeyBoundsWithConn(ctx context.Context, conn pq.C
 	}
 
 	return minValue, maxValue, true, nil
+}
+
+func (s *Snapshotter) buildPrimaryKeyBoundsQuery(table publication.Table, pkColumn string) string {
+	query := fmt.Sprintf(`
+		SELECT MIN(%s)::bigint AS min_value, MAX(%s)::bigint AS max_value
+		FROM %s.%s
+	`, pkColumn, pkColumn, table.Schema, table.Name)
+	if queryCondition := s.getQueryCondition(table.Schema, table.Name); queryCondition != "" {
+		query += " WHERE (" + queryCondition + ")"
+	}
+	return query
 }
 
 // parseRow converts PostgreSQL row data to map with proper type conversion

--- a/pq/snapshot/coordinator_test.go
+++ b/pq/snapshot/coordinator_test.go
@@ -90,6 +90,20 @@ func TestGetQueryCondition(t *testing.T) {
 	})
 }
 
+func TestBuildPrimaryKeyBoundsQueryWithCondition(t *testing.T) {
+	s := &Snapshotter{
+		config: config.SnapshotConfig{QueryCondition: "deleted_at IS NULL"},
+	}
+
+	query := s.buildPrimaryKeyBoundsQuery(publication.Table{
+		Schema: "public",
+		Name:   "users",
+	}, "id")
+
+	assert.Contains(t, query, "FROM public.users")
+	assert.Contains(t, query, "WHERE (deleted_at IS NULL)")
+}
+
 func TestBuildChunkQueryWithCondition(t *testing.T) {
 	s := &Snapshotter{}
 


### PR DESCRIPTION
Integer-range snapshot partitioning currently calculates MIN/MAX across the full table. With filtered snapshots and sparse matching rows, this creates many empty chunks and can delay startup.

Apply the effective table or global snapshot condition when calculating primary-key bounds. Chunk queries already use the same condition.

Test: `go test ./pq/snapshot`