### PR TITLE
fix(stream): keep committed rows on sub-transaction STREAM ABORT

### DIFF
--- a/integration_test/streaming_subtransaction_rollback_test.go
+++ b/integration_test/streaming_subtransaction_rollback_test.go
@@ -1,0 +1,122 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	cdc "github.com/Trendyol/go-pq-cdc"
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/Trendyol/go-pq-cdc/pq/replication"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStreamingSubTransactionRollback verifies that ROLLBACK TO SAVEPOINT inside
+// a streamed transaction drops only the savepoint's rows. PostgreSQL sends
+// STREAM ABORT with SubXid != Xid for it; treating that as a whole-transaction
+// abort used to lose every row of the transaction.
+func TestStreamingSubTransactionRollback(t *testing.T) {
+	const (
+		keptRows     = 500
+		rolledBack   = 500
+		afterRows    = 5
+		slotName     = "slot_test_stream_subtx_rollback"
+		keptBase     = 90000
+		rollbackBase = 91000
+		afterBase    = 92000
+	)
+
+	ctx := context.Background()
+	lowerLogicalDecodingWorkMem(ctx, t)
+
+	cdcCfg := Config
+	cdcCfg.Slot.Name = slotName
+	cdcCfg.Slot.ProtoVersion = 2
+
+	postgresConn, err := newPostgresConn()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	if !assert.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg)) {
+		t.FailNow()
+	}
+
+	msgCh := make(chan *format.Insert, keptRows+rolledBack+afterRows)
+	handler := func(lCtx *replication.ListenerContext) {
+		if ins, ok := lCtx.Message.(*format.Insert); ok {
+			msgCh <- ins
+		}
+		_ = lCtx.Ack()
+	}
+
+	connector, err := cdc.NewConnector(ctx, cdcCfg, handler)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	cfg := config.Config{Host: Config.Host, Port: Config.Port, Username: "postgres", Password: "postgres", Database: Config.Database}
+	pool, err := pgxpool.New(ctx, cfg.DSNWithoutSSL())
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	t.Cleanup(func() {
+		connector.Close()
+		_ = RestoreDB(ctx)
+		pool.Close()
+		_ = postgresConn.Close(ctx)
+	})
+
+	go connector.Start(ctx)
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	assert.NoError(t, connector.WaitUntilReady(waitCtx))
+	cancel()
+
+	tx, err := pool.Begin(ctx)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	for i := 0; i < keptRows; i++ {
+		_, err = tx.Exec(ctx, "INSERT INTO books (id, name) VALUES ($1, $2)", keptBase+i, fmt.Sprintf("kept-%d", i))
+		assert.NoError(t, err)
+	}
+	_, err = tx.Exec(ctx, "SAVEPOINT sp")
+	assert.NoError(t, err)
+	for i := 0; i < rolledBack; i++ {
+		_, err = tx.Exec(ctx, "INSERT INTO books (id, name) VALUES ($1, $2)", rollbackBase+i, fmt.Sprintf("rolled-back-%d", i))
+		assert.NoError(t, err)
+	}
+	_, err = tx.Exec(ctx, "ROLLBACK TO SAVEPOINT sp")
+	assert.NoError(t, err)
+	for i := 0; i < afterRows; i++ {
+		_, err = tx.Exec(ctx, "INSERT INTO books (id, name) VALUES ($1, $2)", afterBase+i, fmt.Sprintf("after-%d", i))
+		assert.NoError(t, err)
+	}
+	assert.NoError(t, tx.Commit(ctx))
+
+	want := keptRows + afterRows
+	got := make(map[int32]struct{}, want)
+	deadline := time.After(15 * time.Second)
+	for len(got) < want {
+		select {
+		case <-deadline:
+			t.Fatalf("timeout: expected %d insert messages, got %d", want, len(got))
+		case ins := <-msgCh:
+			id := ins.Decoded["id"].(int32)
+			if id >= rollbackBase && id < rollbackBase+rolledBack {
+				t.Fatalf("row %d from the rolled-back savepoint was delivered", id)
+			}
+			got[id] = struct{}{}
+		}
+	}
+
+	// Nothing else may leak through after the expected rows.
+	select {
+	case ins := <-msgCh:
+		t.Fatalf("unexpected extra insert delivered: id=%v", ins.Decoded["id"])
+	case <-time.After(time.Second):
+	}
+}

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -242,26 +242,54 @@ func (b *messageBuffer) buffer(msg *Message) {
 // how PostgreSQL's own logical replication worker handles streaming: it writes
 // to temporary storage and only applies on commit.
 type streamTxBuffer struct {
-	ctx       context.Context
-	txns      map[uint32][]*Message
+	ctx  context.Context
+	txns map[uint32][]*Message
+	// subXacts records, per top-level XID, every sub-transaction XID in the
+	// order it first appeared together with the txns index of its first
+	// message. STREAM ABORT for a sub-transaction truncates txns at that
+	// index, mirroring PostgreSQL's worker.c stream_abort_internal.
+	subXacts  map[uint32][]subXact
 	activeXid uint32
 	streaming bool
+}
+
+type subXact struct {
+	xid   uint32
+	index int
 }
 
 // startTx marks the beginning of a streaming chunk for the given XID.
 func (s *streamTxBuffer) startTx(xid uint32) {
 	if s.txns == nil {
 		s.txns = make(map[uint32][]*Message)
+		s.subXacts = make(map[uint32][]subXact)
 	}
 	s.activeXid = xid
 	s.streaming = true
 }
 
 // append adds a message to the currently active streaming transaction.
-func (s *streamTxBuffer) append(msg *Message) {
-	if msg != nil {
-		s.txns[s.activeXid] = append(s.txns[s.activeXid], msg)
+// xid is the (sub)transaction the message was decoded with; a value other
+// than the active top-level XID marks a sub-transaction.
+func (s *streamTxBuffer) append(msg *Message, xid uint32) {
+	if msg == nil {
+		return
 	}
+	if xid != s.activeXid && !s.hasSubXact(xid) {
+		s.subXacts[s.activeXid] = append(s.subXacts[s.activeXid], subXact{xid: xid, index: len(s.txns[s.activeXid])})
+	}
+	s.txns[s.activeXid] = append(s.txns[s.activeXid], msg)
+}
+
+func (s *streamTxBuffer) hasSubXact(xid uint32) bool {
+	subs := s.subXacts[s.activeXid]
+	// Scan from the tail: a message almost always belongs to the most recent sub-transaction.
+	for i := len(subs) - 1; i >= 0; i-- {
+		if subs[i].xid == xid {
+			return true
+		}
+	}
+	return false
 }
 
 // stopTx marks the end of the current streaming chunk.
@@ -294,12 +322,29 @@ func (s *streamTxBuffer) flushTx(xid uint32, outCh chan<- *Message, endLSN pq.LS
 		}
 	}
 	delete(s.txns, xid)
+	delete(s.subXacts, xid)
 }
 
-// discardTx drops all accumulated messages for the given XID without emitting.
-func (s *streamTxBuffer) discardTx(xid uint32) {
+// abortTx handles STREAM ABORT. subXid == xid rolls back the whole
+// transaction. Otherwise only the sub-transaction is rolled back: every
+// message from its first appearance onwards is dropped (later sub-transactions
+// are nested in or follow it, so they are gone too); messages before it stay.
+func (s *streamTxBuffer) abortTx(xid, subXid uint32) {
 	s.streaming = false
-	delete(s.txns, xid)
+	if subXid == xid {
+		delete(s.txns, xid)
+		delete(s.subXacts, xid)
+		return
+	}
+	subs := s.subXacts[xid]
+	for i := len(subs) - 1; i >= 0; i-- {
+		if subs[i].xid == subXid {
+			s.txns[xid] = s.txns[xid][:subs[i].index]
+			s.subXacts[xid] = subs[:i]
+			return
+		}
+	}
+	// Unknown sub-transaction: none of its changes reached us, nothing to drop.
 }
 
 func (s *stream) sink(ctx context.Context) {
@@ -480,7 +525,8 @@ func (s *stream) handleXLogData(data []byte, buf *messageBuffer, streamBuf *stre
 //
 // For streaming transactions (proto v2) messages are accumulated in the
 // streamTxBuffer across STREAM START / STREAM STOP chunks. They are only
-// emitted to the consumer on STREAM COMMIT and discarded on STREAM ABORT.
+// emitted to the consumer on STREAM COMMIT and discarded on STREAM ABORT
+// (whole transaction or, for a sub-transaction abort, only its own changes).
 // This prevents uncommitted data from being delivered.
 func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffer, streamBuf *streamTxBuffer) {
 	switch msg := decodedMsg.(type) {
@@ -504,8 +550,9 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 		streamBuf.flushTx(msg.Xid, buf.outCh, msg.TransactionEndLSN)
 
 	case *format.StreamAbort:
-		// Streamed transaction rolled back – discard messages for this XID.
-		streamBuf.discardTx(msg.Xid)
+		// Whole transaction (SubXid == Xid) or a single sub-transaction
+		// (ROLLBACK TO SAVEPOINT, plpgsql EXCEPTION block) rolled back.
+		streamBuf.abortTx(msg.Xid, msg.SubXid)
 
 	default:
 		// DML event (Insert, Update, Delete, Relation, …)
@@ -514,11 +561,29 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 			walStart: int64(xld.WALStart),
 		}
 		if streamBuf.streaming {
-			streamBuf.append(m)
+			streamBuf.append(m, messageXid(decodedMsg))
 		} else {
 			buf.buffer(m)
 		}
 	}
+}
+
+// messageXid returns the (sub)transaction XID a streamed message was decoded
+// with (proto v2 prefixes every message inside STREAM START/STOP with it).
+func messageXid(msg any) uint32 {
+	switch m := msg.(type) {
+	case *format.Insert:
+		return m.XID
+	case *format.Update:
+		return m.XID
+	case *format.Delete:
+		return m.XID
+	case *format.Truncate:
+		return m.XID
+	case *format.Relation:
+		return m.XID
+	}
+	return 0
 }
 
 func (s *stream) process(ctx context.Context) {

--- a/pq/replication/stream_abort_test.go
+++ b/pq/replication/stream_abort_test.go
@@ -1,0 +1,155 @@
+package replication
+
+import (
+	"testing"
+
+	"github.com/Trendyol/go-pq-cdc/pq"
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/stretchr/testify/assert"
+)
+
+// streamAbortHarness drives dispatchMessage with decoded proto v2 streaming
+// messages and collects what reaches the consumer channel.
+type streamAbortHarness struct {
+	s         *stream
+	buf       *messageBuffer
+	streamBuf *streamTxBuffer
+	out       chan *Message
+}
+
+func newStreamAbortHarness() *streamAbortHarness {
+	out := make(chan *Message, 100)
+	return &streamAbortHarness{
+		s:         &stream{},
+		buf:       &messageBuffer{outCh: out},
+		streamBuf: &streamTxBuffer{},
+		out:       out,
+	}
+}
+
+func (h *streamAbortHarness) dispatch(msg any, lsn uint64) {
+	h.s.dispatchMessage(msg, XLogData{WALStart: pq.LSN(lsn)}, h.buf, h.streamBuf)
+}
+
+func (h *streamAbortHarness) insert(xid uint32, name string, lsn uint64) {
+	h.dispatch(&format.Insert{XID: xid, TableName: name}, lsn)
+}
+
+func (h *streamAbortHarness) delivered() []string {
+	var names []string
+	for {
+		select {
+		case m := <-h.out:
+			names = append(names, m.message.(*format.Insert).TableName)
+		default:
+			return names
+		}
+	}
+}
+
+func TestStreamAbortSubTransactionKeepsEarlierChanges(t *testing.T) {
+	// BEGIN(100); INSERT a; SAVEPOINT(101); INSERT b; INSERT c; ROLLBACK TO SAVEPOINT; INSERT d; COMMIT
+	h := newStreamAbortHarness()
+	h.dispatch(&format.StreamStart{Xid: 100}, 1)
+	h.insert(100, "a", 10)
+	h.insert(101, "b", 11)
+	h.insert(101, "c", 12)
+	h.dispatch(&format.StreamStop{}, 13)
+	h.dispatch(&format.StreamAbort{Xid: 100, SubXid: 101}, 14)
+	h.dispatch(&format.StreamStart{Xid: 100}, 15)
+	h.insert(100, "d", 16)
+	h.dispatch(&format.StreamStop{}, 17)
+	h.dispatch(&format.StreamCommit{Xid: 100, TransactionEndLSN: 99}, 18)
+
+	assert.Equal(t, []string{"a", "d"}, h.delivered())
+}
+
+func TestStreamAbortNestedSubTransactions(t *testing.T) {
+	// INSERT a(100); SAVEPOINT s1(101); INSERT b; SAVEPOINT s2(102); INSERT c;
+	// ROLLBACK TO s2 → abort 102; INSERT e(101); RELEASE s1; ROLLBACK TO s0 … then
+	// a second nested case: abort of the outer sub-xid drops the inner one too.
+	h := newStreamAbortHarness()
+	h.dispatch(&format.StreamStart{Xid: 100}, 1)
+	h.insert(100, "a", 10)
+	h.insert(101, "b", 11)
+	h.insert(102, "c", 12)
+	h.dispatch(&format.StreamStop{}, 13)
+	h.dispatch(&format.StreamAbort{Xid: 100, SubXid: 102}, 14)
+	h.dispatch(&format.StreamStart{Xid: 100}, 15)
+	h.insert(101, "e", 16)
+	h.insert(103, "f", 17)
+	h.dispatch(&format.StreamStop{}, 18)
+	// PostgreSQL sends the innermost abort first, then the outer one.
+	h.dispatch(&format.StreamAbort{Xid: 100, SubXid: 103}, 19)
+	h.dispatch(&format.StreamAbort{Xid: 100, SubXid: 101}, 20)
+	h.dispatch(&format.StreamStart{Xid: 100}, 21)
+	h.insert(100, "g", 22)
+	h.dispatch(&format.StreamStop{}, 23)
+	h.dispatch(&format.StreamCommit{Xid: 100, TransactionEndLSN: 99}, 24)
+
+	assert.Equal(t, []string{"a", "g"}, h.delivered())
+}
+
+func TestStreamAbortSubTransactionInterleavedTransactions(t *testing.T) {
+	// TX-A chunk (with sub-xid), TX-B chunk, TX-A sub-abort: B untouched, A keeps its top-level rows.
+	h := newStreamAbortHarness()
+	h.dispatch(&format.StreamStart{Xid: 100}, 1)
+	h.insert(100, "a1", 10)
+	h.insert(101, "a-sub", 11)
+	h.dispatch(&format.StreamStop{}, 12)
+	h.dispatch(&format.StreamStart{Xid: 200}, 13)
+	h.insert(200, "b1", 14)
+	h.insert(201, "b-sub", 15)
+	h.dispatch(&format.StreamStop{}, 16)
+	h.dispatch(&format.StreamAbort{Xid: 100, SubXid: 101}, 17)
+	h.dispatch(&format.StreamCommit{Xid: 200, TransactionEndLSN: 50}, 18)
+	h.dispatch(&format.StreamStart{Xid: 100}, 19)
+	h.insert(100, "a2", 20)
+	h.dispatch(&format.StreamStop{}, 21)
+	h.dispatch(&format.StreamCommit{Xid: 100, TransactionEndLSN: 99}, 22)
+
+	assert.Equal(t, []string{"b1", "b-sub", "a1", "a2"}, h.delivered())
+	assert.Empty(t, h.streamBuf.txns)
+	assert.Empty(t, h.streamBuf.subXacts)
+}
+
+func TestStreamAbortTopLevelDiscardsEverything(t *testing.T) {
+	h := newStreamAbortHarness()
+	h.dispatch(&format.StreamStart{Xid: 100}, 1)
+	h.insert(100, "a", 10)
+	h.insert(101, "b", 11)
+	h.dispatch(&format.StreamStop{}, 12)
+	// PostgreSQL aborts the sub-transactions first, then the top-level one.
+	h.dispatch(&format.StreamAbort{Xid: 100, SubXid: 101}, 13)
+	h.dispatch(&format.StreamAbort{Xid: 100, SubXid: 100}, 14)
+
+	assert.Empty(t, h.delivered())
+	assert.Empty(t, h.streamBuf.txns)
+	assert.Empty(t, h.streamBuf.subXacts)
+}
+
+func TestStreamAbortUnknownSubTransactionIsNoop(t *testing.T) {
+	h := newStreamAbortHarness()
+	h.dispatch(&format.StreamStart{Xid: 100}, 1)
+	h.insert(100, "a", 10)
+	h.dispatch(&format.StreamStop{}, 11)
+	h.dispatch(&format.StreamAbort{Xid: 100, SubXid: 555}, 12)
+	h.dispatch(&format.StreamCommit{Xid: 100, TransactionEndLSN: 99}, 13)
+
+	assert.Equal(t, []string{"a"}, h.delivered())
+}
+
+func TestStreamAbortSubTransactionRewritesLastLSN(t *testing.T) {
+	// After truncation the surviving last message must carry the transaction-end LSN.
+	h := newStreamAbortHarness()
+	h.dispatch(&format.StreamStart{Xid: 100}, 1)
+	h.insert(100, "a", 10)
+	h.insert(101, "b", 11)
+	h.dispatch(&format.StreamStop{}, 12)
+	h.dispatch(&format.StreamAbort{Xid: 100, SubXid: 101}, 13)
+	h.dispatch(&format.StreamCommit{Xid: 100, TransactionEndLSN: 99}, 14)
+
+	m := <-h.out
+	assert.Equal(t, "a", m.message.(*format.Insert).TableName)
+	assert.Equal(t, int64(99), m.walStart)
+}


### PR DESCRIPTION
## Bug

`format.StreamAbort` carries `Xid` **and** `SubXid`. A `ROLLBACK TO SAVEPOINT` or a plpgsql `EXCEPTION` block inside a transaction larger than `logical_decoding_work_mem` makes PostgreSQL send `STREAM ABORT` with `SubXid != Xid` (`pgoutput_stream_abort` writes `toptxn->xid, txn->xid`). `dispatchMessage` called `streamBuf.discardTx(msg.Xid)` on every `StreamAbort`, so the whole per-XID buffer was dropped and `STREAM COMMIT` then emitted nothing for the rows that actually committed.

The default config (proto v2, streaming on) is affected. Reproduced against PostgreSQL 15 and 16: with 500 committed rows, a 500-row savepoint rolled back, then 5 more rows, the old code delivered **5 of 505** rows.

## Fix

Mirror `worker.c stream_abort_internal`: streamed DML/Relation/Truncate messages already carry the (sub)xid they were decoded with. `streamTxBuffer.append` now records, per top-level XID, the buffer index at which each new sub-xid first appears. On `STREAM ABORT` with `SubXid != Xid` the buffer is truncated to that index and the sub-xids recorded at or after it are dropped (later sub-transactions are nested in or follow the aborted one). Only `SubXid == Xid` discards the whole transaction. An unknown sub-xid is a no-op (its changes never reached us; PostgreSQL never streams empty sub-xacts).

## Tests

- Unit (`stream_abort_test.go`, drives `dispatchMessage`): sub-abort in the middle of a chunk, nested sub-xids with PostgreSQL's innermost-first abort order, interleaved transactions (TX-A chunk, TX-B chunk, TX-A sub-abort), top-level abort, unknown sub-xid, end-LSN rewrite of the surviving last message.
- Integration (`streaming_subtransaction_rollback_test.go`): real `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` under `logical_decoding_work_mem = 64kB`; fails on `main`, passes here on 15-alpine and 16-alpine.