### PR TITLE
feat(stream): expose CommitLSN on every delivered message

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,22 @@ Streaming behavior for `proto_version: 2`:
 - `STREAM ABORT` discards all buffered events for that transaction.
 - This prevents rolled-back streamed transactions from leaking to consumers.
 
+### Commit LSN and reading from a standby
+
+Every CDC event exposes `ctx.CommitLSN`: the WAL position of the commit record of the transaction that produced it
+(pgoutput `Begin.FinalLSN`, or `StreamCommit.CommitLSN` for streamed transactions). Snapshot events carry `0`.
+
+`visibilityGuard` only describes the primary. A consumer that reads from a standby, or through a pooler that may route
+to one, has to wait until the standby has replayed that commit record. The rule is **strict**:
+
+```sql
+SELECT pg_last_wal_replay_lsn() > '<ctx.CommitLSN>'::pg_lsn;
+```
+
+`pg_last_wal_replay_lsn()` reports the end of the last replayed record, so it equals `CommitLSN` right before the commit
+record itself is applied; `>=` is not enough. On PostgreSQL 17+ `pg_wal_replay_wait('<ctx.CommitLSN>')` can replace
+polling, followed by the same strict check. `ctx.CommitLSN.String()` prints the `pg_lsn` text form (`X/X`).
+
 ### Exposed Metrics
 
 The client collects relevant metrics related to PostgreSQL change data capture (CDC) and makes them available at

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -40,6 +40,15 @@ type ListenerContext struct {
 	Context context.Context
 	Message any
 	Ack     func() error
+	// CommitLSN is the start of the commit record of the transaction that
+	// produced Message (pgoutput Begin.FinalLSN, StreamCommit.CommitLSN for
+	// streamed transactions). Zero for snapshot events.
+	//
+	// A standby has applied that transaction only once
+	// pg_last_wal_replay_lsn() > CommitLSN. The comparison is strict:
+	// pg_last_wal_replay_lsn() reports the end of the last replayed record, so
+	// it equals CommitLSN right before the commit record itself is applied.
+	CommitLSN pq.LSN
 }
 
 type ListenerFunc func(ctx *ListenerContext)
@@ -50,6 +59,9 @@ type Message struct {
 	// xid is the top-level transaction the message belongs to (Begin.Xid or
 	// StreamStart.Xid); the visibility guard gates on it.
 	xid uint32
+	// commitLSN is the start of the transaction's commit record, exposed as
+	// ListenerContext.CommitLSN.
+	commitLSN pq.LSN
 }
 
 type Streamer interface {
@@ -191,10 +203,11 @@ func (s *stream) setup(ctx context.Context) error {
 // All preceding messages are emitted immediately with their original position.
 // This keeps memory usage O(1) regardless of transaction size.
 type messageBuffer struct {
-	pending *Message
-	outCh   chan<- *Message
-	ctx     context.Context
-	xid     uint32 // current transaction, from Begin
+	pending   *Message
+	outCh     chan<- *Message
+	ctx       context.Context
+	xid       uint32 // current transaction, from Begin
+	commitLSN pq.LSN // current transaction's commit record, from Begin.FinalLSN
 }
 
 func (b *messageBuffer) send(msg *Message) bool {
@@ -224,9 +237,10 @@ func (b *messageBuffer) flush() {
 func (b *messageBuffer) flushWithLSN(lsn pq.LSN) {
 	if b.pending != nil {
 		if !b.send(&Message{
-			message:  b.pending.message,
-			walStart: int64(lsn),
-			xid:      b.pending.xid,
+			message:   b.pending.message,
+			walStart:  int64(lsn),
+			xid:       b.pending.xid,
+			commitLSN: b.pending.commitLSN,
 		}) {
 			return
 		}
@@ -314,18 +328,21 @@ func (s *streamTxBuffer) stopTx() {
 }
 
 // flushTx emits every accumulated message for the given XID through outCh.
-// The last message's WAL position is rewritten to the transaction-end LSN.
-func (s *streamTxBuffer) flushTx(xid uint32, outCh chan<- *Message, endLSN pq.LSN) {
+// Every message is stamped with the commit LSN (known only at STREAM COMMIT);
+// the last message's WAL position is rewritten to the transaction-end LSN.
+func (s *streamTxBuffer) flushTx(xid uint32, outCh chan<- *Message, commitLSN, endLSN pq.LSN) {
 	s.streaming = false
 	msgs := s.txns[xid]
 	n := len(msgs)
 	for i, msg := range msgs {
+		msg.commitLSN = commitLSN
 		out := msg
 		if i == n-1 {
 			out = &Message{
-				message:  msg.message,
-				walStart: int64(endLSN),
-				xid:      msg.xid,
+				message:   msg.message,
+				walStart:  int64(endLSN),
+				xid:       msg.xid,
+				commitLSN: commitLSN,
 			}
 		}
 		ctx := s.ctx
@@ -550,6 +567,7 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 	case *format.Begin:
 		buf.discard()
 		buf.xid = msg.Xid
+		buf.commitLSN = msg.FinalLSN
 
 	case *format.Commit:
 		buf.flushWithLSN(msg.TransactionEndLSN)
@@ -565,7 +583,7 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 
 	case *format.StreamCommit:
 		// Final commit of a streamed transaction – emit all messages for this XID.
-		streamBuf.flushTx(msg.Xid, buf.outCh, msg.TransactionEndLSN)
+		streamBuf.flushTx(msg.Xid, buf.outCh, msg.CommitLSN, msg.TransactionEndLSN)
 
 	case *format.StreamAbort:
 		// Whole transaction (SubXid == Xid) or a single sub-transaction
@@ -583,6 +601,7 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 			streamBuf.append(m, messageXid(decodedMsg))
 		} else {
 			m.xid = buf.xid
+			m.commitLSN = buf.commitLSN
 			buf.buffer(m)
 		}
 	}
@@ -685,9 +704,10 @@ func (s *stream) processLoop(ctx context.Context) error {
 			}
 
 			lCtx := &ListenerContext{
-				Context: ctx,
-				Message: msg.message,
-				Ack:     ackFunc,
+				Context:   ctx,
+				Message:   msg.message,
+				Ack:       ackFunc,
+				CommitLSN: msg.commitLSN,
 			}
 
 			switch lCtx.Message.(type) {

--- a/pq/replication/stream_gate_test.go
+++ b/pq/replication/stream_gate_test.go
@@ -22,6 +22,7 @@ type gatedStream struct {
 	q        *scriptedQuery
 	m        *countingMetric
 	received []uint32 // xids delivered to the listener
+	commits  []pq.LSN // CommitLSN seen by the listener, in delivery order
 }
 
 func newGatedStream(t *testing.T, cfg config.Config, rows [][]string) *gatedStream {
@@ -30,6 +31,7 @@ func newGatedStream(t *testing.T, cfg config.Config, rows [][]string) *gatedStre
 	gs := &gatedStream{q: &scriptedQuery{rows: rows}}
 	gs.s = NewStream("", cfg, nil, func(ctx *ListenerContext) {
 		gs.received = append(gs.received, ctx.Message.(*format.Insert).XID)
+		gs.commits = append(gs.commits, ctx.CommitLSN)
 		_ = ctx.Ack()
 	}).(*stream)
 	guard, m := testGuard(gs.q.query)
@@ -49,7 +51,7 @@ func (gs *gatedStream) run(msgs ...*Message) error {
 }
 
 func insertMsg(xid uint32, lsn int64) *Message {
-	return &Message{message: &format.Insert{XID: xid, TableName: "books"}, walStart: lsn, xid: xid}
+	return &Message{message: &format.Insert{XID: xid, TableName: "books"}, walStart: lsn, xid: xid, commitLSN: pq.LSN(lsn)}
 }
 
 func guardCfg(mode config.VisibilityFailMode) config.Config {
@@ -139,46 +141,43 @@ func TestGateDisabledDoesNotTouchGuard(t *testing.T) {
 
 	require.NoError(t, gs.run(insertMsg(200, 1)))
 	assert.Equal(t, []uint32{200}, gs.received)
+	assert.Equal(t, []pq.LSN{1}, gs.commits, "ListenerContext.CommitLSN comes from Message.commitLSN")
 	assert.Equal(t, int32(0), gs.q.calls.Load())
 }
 
-func TestDispatchStampsXidOnNonStreamingAndStreamingPaths(t *testing.T) {
+func TestDispatchStampsXidAndCommitLSNOnNonStreamingAndStreamingPaths(t *testing.T) {
 	out := make(chan *Message, 10)
 	s := &stream{}
 	buf := &messageBuffer{outCh: out}
 	streamBuf := &streamTxBuffer{}
 	dispatch := func(msg any, lsn uint64) { s.dispatchMessage(msg, XLogData{WALStart: pq.LSN(lsn)}, buf, streamBuf) }
 
-	// Non-streaming: BEGIN(100) a b COMMIT → both carry 100; the last one is rebuilt by flushWithLSN.
-	dispatch(&format.Begin{Xid: 100}, 1)
+	// Non-streaming: BEGIN(100, final 40) a b COMMIT → both carry xid 100 and commit 40 (from Begin.FinalLSN);
+	// the last one is rebuilt by flushWithLSN.
+	dispatch(&format.Begin{Xid: 100, FinalLSN: 40}, 1)
 	dispatch(&format.Insert{TableName: "a"}, 2)
 	dispatch(&format.Insert{TableName: "b"}, 3)
-	dispatch(&format.Commit{TransactionEndLSN: 50}, 4)
-	// Streaming: STREAM START(200) c(sub 201) d STREAM STOP STREAM COMMIT → both carry the top-level 200.
+	dispatch(&format.Commit{CommitLSN: 40, TransactionEndLSN: 50}, 4)
+	// Streaming: STREAM START(200) c(sub 201) d STREAM STOP STREAM COMMIT(commit 90, end 99) → both carry the
+	// top-level 200 and commit 90, which is only known at STREAM COMMIT.
 	dispatch(&format.StreamStart{Xid: 200}, 5)
 	dispatch(&format.Insert{XID: 201, TableName: "c"}, 6)
 	dispatch(&format.Insert{XID: 200, TableName: "d"}, 7)
 	dispatch(&format.StreamStop{}, 8)
-	dispatch(&format.StreamCommit{Xid: 200, TransactionEndLSN: 99}, 9)
+	dispatch(&format.StreamCommit{Xid: 200, CommitLSN: 90, TransactionEndLSN: 99}, 9)
 	close(out)
 
-	var got []struct {
-		name string
-		xid  uint32
-		lsn  int64
+	type stamped struct {
+		name   string
+		xid    uint32
+		lsn    int64
+		commit pq.LSN
 	}
+	var got []stamped
 	for m := range out {
-		got = append(got, struct {
-			name string
-			xid  uint32
-			lsn  int64
-		}{m.message.(*format.Insert).TableName, m.xid, m.walStart})
+		got = append(got, stamped{m.message.(*format.Insert).TableName, m.xid, m.walStart, m.commitLSN})
 	}
-	assert.Equal(t, []struct {
-		name string
-		xid  uint32
-		lsn  int64
-	}{{"a", 100, 2}, {"b", 100, 50}, {"c", 200, 6}, {"d", 200, 99}}, got)
+	assert.Equal(t, []stamped{{"a", 100, 2, 40}, {"b", 100, 50, 40}, {"c", 200, 6, 90}, {"d", 200, 99, 90}}, got)
 }
 
 func TestCloseCancelsBeforeClosingGuardAndAfterProcessExit(t *testing.T) {


### PR DESCRIPTION
Step 2 of `docs/visibility-gate-design.md` (P7). Stacked on #167 (`feature/visibility-guard`); retarget to `main` once #167 merges.

## What

- `ListenerContext.CommitLSN pq.LSN`: start of the commit record of the transaction that produced the event. `0` for snapshot events.
- Non-streaming: stamped from `Begin.FinalLSN` at BEGIN, so the one-message look-ahead buffer carries it before COMMIT arrives; `flushWithLSN` copies it.
- Streaming: `flushTx` stamps every buffered message from `StreamCommit.CommitLSN`, the only point where it is known.
- README: new "Commit LSN and reading from a standby" section with the **strict** rule `pg_last_wal_replay_lsn() > CommitLSN` and why `>=` is not enough (replay position equals `CommitLSN` right before the commit record is applied). PG17 `pg_wal_replay_wait` mentioned as the non-polling variant, followed by the same strict check.

## One note on the handoff text

The build-order note says "`StreamCommit.TransactionEndLSN` is available in `flushTx`; still name the field `CommitLSN`". `format.StreamCommit` already parses the commit LSN (`StreamCommit.CommitLSN`, same wire field as `Begin.FinalLSN` for that transaction), so the streaming path uses it. That keeps P7's definition ("`CommitLSN` = start of the commit record") identical on both paths, and keeps the strict `>` rule tight: with the end LSN the strict check would only pass after the *next* WAL record is replayed, which on an idle primary can be arbitrarily late.

## Tests

- `TestDispatchStampsXidAndCommitLSNOnNonStreamingAndStreamingPaths`: BEGIN/COMMIT and STREAM START/COMMIT paths, including the rebuilt last message on each path.
- Gate harness now records `ListenerContext.CommitLSN`, asserting the value survives `processLoop`.
- `go test ./pq/replication/`, `go vet ./...` pass locally.