### PR TITLE
feat(slot): opt-in failover slots (PostgreSQL 17+)

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ "15-alpine",  "15.7-alpine", "16-alpine", "16.3-alpine" ]
+        version: [ "15-alpine",  "15.7-alpine", "16-alpine", "16.3-alpine", "17-alpine" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ You can run [Replica Identity Nothing](./example/replica-identity-nothing) for a
 | `slot.name`                             |  string  |   yes    |    -    | Set the logical replication slot name                                                                 | Should be unique and descriptive.                                                                                                                  |
 | `slot.slotActivityCheckerInterval`      |   int    |    no    |  1000   | Set the slot activity check interval time in milliseconds                                             | Specify as an integer value in milliseconds (e.g., `1000` for 1 second).                                                                           |
 | `slot.protoVersion`                     |   int    |    no    |    2    | `pgoutput` protocol version used in `START_REPLICATION`                                               | `1`: PostgreSQL 10+ compatibility, no streaming transaction protocol messages. `2`: PostgreSQL 14+, enables streaming/messages options.           |
+| `slot.failover`                         |   bool   |    no    |  false  | Create the slot with `FAILOVER true` (PostgreSQL 17+) so standbys running `sync_replication_slots` keep a synchronized copy; an existing slot is altered with `ALTER_REPLICATION_SLOT … (FAILOVER true)`. | Rejected with a clear error on older servers. Needs `synchronized_standby_slots` on the primary, see [Failover slots](#failover-slots-postgresql-17). |
 | `snapshot.enabled`                      |   bool   |    no    |  false  | Enable initial snapshot feature                                                                       | When enabled, captures existing data before starting CDC.                                                                                          |
 | `snapshot.mode`                         |  string  |    no    |  never  | Snapshot mode: `initial`, `never`, or `snapshot_only`                                                 | **initial:** Take snapshot only if no previous snapshot exists, then start CDC. <br> **never:** Skip snapshot, start CDC immediately. <br> **snapshot_only:** Take snapshot and exit (no CDC, no replication slot required). |
 | `snapshot.chunkSize`                    |  int64   |    no    |  8000   | Number of rows per chunk during snapshot                                                              | Adjust based on table size. Larger chunks = fewer chunks but more memory per chunk.                                                               |
@@ -441,6 +442,29 @@ SELECT pg_last_wal_replay_lsn() > '<ctx.CommitLSN>'::pg_lsn;
 `pg_last_wal_replay_lsn()` reports the end of the last replayed record, so it equals `CommitLSN` right before the commit
 record itself is applied; `>=` is not enough. On PostgreSQL 17+ `pg_wal_replay_wait('<ctx.CommitLSN>')` can replace
 polling, followed by the same strict check. `ctx.CommitLSN.String()` prints the `pg_lsn` text form (`X/X`).
+
+### Failover slots (PostgreSQL 17+)
+
+`slot.failover: true` creates the replication slot with `FAILOVER true`, or issues
+`ALTER_REPLICATION_SLOT … (FAILOVER true)` for an existing slot, so a standby running `sync_replication_slots` keeps a
+synchronized copy and the slot survives a failover without WAL loss. Servers older than 17 reject the option with a clear
+error. Required setup:
+
+- **Primary:** `synchronized_standby_slots = 'standby_physical_slot'`. The logical walsender then waits for the listed
+  physical slots before sending a change, so no event is delivered ahead of the standby that may become the next
+  primary. With the parameter empty there is no waiting: the synchronized slot can lag behind what consumers have already
+  seen, and those events are redelivered after failover.
+- **Standby:** `sync_replication_slots = on`, `hot_standby_feedback = on`, `primary_slot_name` set, and `dbname` in
+  `primary_conninfo`.
+- An inactive slot listed in `synchronized_standby_slots` stalls the logical walsender; remove it from the list before
+  taking that standby down for good.
+- Patroni 4.1.0+ leaves `failover = true` slots alone (no copy, no `pg_replication_slot_advance`) but does not set
+  `synchronized_standby_slots`; set it through `postgresql.parameters`.
+- If the slot is active for another process when go-pq-cdc starts (rolling deployment), the `ALTER` is skipped with a
+  warning and retried on the next start.
+
+Complementary to `visibilityGuard`: the guard closes the read-after-write window on the primary, the failover slot keeps
+the consumer position across a promotion.
 
 ### Exposed Metrics
 

--- a/integration_test/slot_failover_test.go
+++ b/integration_test/slot_failover_test.go
@@ -1,0 +1,84 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"testing"
+
+	"github.com/Trendyol/go-pq-cdc/logger"
+	"github.com/Trendyol/go-pq-cdc/pq"
+	"github.com/Trendyol/go-pq-cdc/pq/slot"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSlotFailover covers slot.failover against a real server: on
+// PostgreSQL 17+ a fresh slot is created with FAILOVER true and an existing
+// slot created without it is altered; older servers reject the option with a
+// clear error instead of a CREATE_REPLICATION_SLOT syntax error.
+func TestSlotFailover(t *testing.T) {
+	const (
+		existingSlot = "slot_test_failover_existing"
+		freshSlot    = "slot_test_failover_fresh"
+	)
+	ctx := context.Background()
+	logger.InitLogger(logger.NewSlog(slog.LevelError)) // slot is used without a connector here
+
+	postgresConn, err := newPostgresConn()
+	require.NoError(t, err)
+	defer func() { _ = postgresConn.Close(ctx) }()
+
+	newSlot := func(name string, failover bool) *slot.Slot {
+		cfg := Config.Slot
+		cfg.Name = name
+		cfg.CreateIfNotExists = true
+		cfg.SlotActivityCheckerInterval = 1000
+		cfg.Failover = failover
+		return slot.NewSlot(Config.ReplicationDSN(), Config.DSN(), cfg, nil, nil)
+	}
+	dropSlot := func(name string) {
+		_ = pgExec(ctx, postgresConn, fmt.Sprintf("SELECT pg_drop_replication_slot('%s') WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '%s')", name, name))
+	}
+	failoverFlag := func(name string) string {
+		return pgScalar(t, ctx, postgresConn, fmt.Sprintf("SELECT failover FROM pg_replication_slots WHERE slot_name = '%s'", name))
+	}
+
+	version, err := strconv.Atoi(pgScalar(t, ctx, postgresConn, "SHOW server_version_num"))
+	require.NoError(t, err)
+
+	if version < 170000 {
+		_, err := newSlot(freshSlot, true).Create(ctx)
+		require.ErrorContains(t, err, "slot.failover requires PostgreSQL 17")
+		return
+	}
+
+	// Existing slot without failover → enabled by ALTER_REPLICATION_SLOT on the next Create.
+	dropSlot(existingSlot)
+	defer dropSlot(existingSlot)
+	_, err = newSlot(existingSlot, false).Create(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "f", failoverFlag(existingSlot))
+	_, err = newSlot(existingSlot, true).Create(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "t", failoverFlag(existingSlot))
+	// Idempotent: already enabled, nothing to alter.
+	_, err = newSlot(existingSlot, true).Create(ctx)
+	require.NoError(t, err)
+
+	// Fresh slot created with FAILOVER true.
+	dropSlot(freshSlot)
+	defer dropSlot(freshSlot)
+	_, err = newSlot(freshSlot, true).Create(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "t", failoverFlag(freshSlot))
+}
+
+func pgScalar(t *testing.T, ctx context.Context, conn pq.Connection, sql string) string {
+	t.Helper()
+	results, err := conn.Exec(ctx, sql).ReadAll()
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	require.NotEmpty(t, results[0].Rows)
+	return string(results[0].Rows[0][0])
+}

--- a/pq/slot/config.go
+++ b/pq/slot/config.go
@@ -14,6 +14,10 @@ type Config struct {
 	//   2 – requires PostgreSQL 14+; supports streaming large in-progress transactions (default).
 	ProtoVersion      int  `json:"protoVersion" yaml:"protoVersion"`
 	CreateIfNotExists bool `json:"createIfNotExists" yaml:"createIfNotExists"`
+	// Failover creates the slot with FAILOVER true (PostgreSQL 17+) so standbys
+	// running sync_replication_slots keep a synchronized copy; an existing slot
+	// is altered. Rejected with a clear error on older servers.
+	Failover bool `json:"failover" yaml:"failover"`
 }
 
 func (c Config) Validate() error {

--- a/pq/slot/slot.go
+++ b/pq/slot/slot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -23,6 +24,10 @@ var (
 )
 
 var typeMap = pgtype.NewMap()
+
+// failoverMinServerVersion is the first server_version_num with
+// CREATE_REPLICATION_SLOT ... (FAILOVER true) and ALTER_REPLICATION_SLOT.
+const failoverMinServerVersion = 170000
 
 type XLogUpdater interface {
 	UpdateXLogPos(l pq.LSN)
@@ -71,6 +76,12 @@ func (s *Slot) Create(ctx context.Context) (*Info, error) {
 		_ = s.conn.Close(ctx)
 	}()
 
+	if s.cfg.Failover {
+		if err := s.checkFailoverSupportLocked(ctx); err != nil {
+			return nil, err
+		}
+	}
+
 	info, err := s.infoLocked(ctx)
 	if err != nil {
 		if !goerrors.Is(err, ErrorSlotIsNotExists) || !s.cfg.CreateIfNotExists {
@@ -78,20 +89,85 @@ func (s *Slot) Create(ctx context.Context) (*Info, error) {
 		}
 	} else {
 		logger.Warn("replication slot already exists")
+		if s.cfg.Failover {
+			if err := s.enableFailoverLocked(ctx, info); err != nil {
+				return nil, err
+			}
+		}
 		return info, nil
 	}
 
 	// Slot needs replication connection for CREATE_REPLICATION_SLOT command
-	if err := s.createSlotWithReplicationConn(ctx); err != nil {
-		return nil, err
+	sql := fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL pgoutput", s.cfg.Name)
+	if s.cfg.Failover {
+		sql += " (FAILOVER true)"
+	}
+	if err := s.execReplicationCommand(ctx, sql); err != nil {
+		return nil, errors.Wrap(err, "replication slot create")
 	}
 
-	logger.Info("replication slot created", "name", s.cfg.Name)
+	logger.Info("replication slot created", "name", s.cfg.Name, "failover", s.cfg.Failover)
 
 	return s.infoLocked(ctx)
 }
 
-func (s *Slot) createSlotWithReplicationConn(ctx context.Context) error {
+// checkFailoverSupportLocked rejects slot.failover on servers older than 17
+// with a clear error instead of a CREATE_REPLICATION_SLOT syntax error.
+func (s *Slot) checkFailoverSupportLocked(ctx context.Context) error {
+	raw, err := s.scalarLocked(ctx, "SHOW server_version_num")
+	if err != nil {
+		return errors.Wrap(err, "server version")
+	}
+	version, err := strconv.Atoi(raw)
+	if err != nil {
+		return errors.Wrapf(err, "server version %q", raw)
+	}
+	if version < failoverMinServerVersion {
+		return errors.Newf("slot.failover requires PostgreSQL 17 or newer (server_version_num %d)", version)
+	}
+	return nil
+}
+
+// enableFailoverLocked turns FAILOVER on for an existing slot created without
+// it. ALTER_REPLICATION_SLOT needs the slot to be free: while another
+// walsender holds it (rolling deployment) the ALTER is skipped with a warning
+// and retried by the next Create.
+func (s *Slot) enableFailoverLocked(ctx context.Context, info *Info) error {
+	failover, err := s.scalarLocked(ctx, fmt.Sprintf("SELECT failover FROM pg_replication_slots WHERE slot_name = '%s'", s.cfg.Name))
+	if err != nil {
+		return errors.Wrap(err, "replication slot failover flag")
+	}
+	if failover == "t" {
+		return nil
+	}
+	if info.Active {
+		logger.Warn("replication slot is active for another process, failover will be enabled once it is released", "name", s.cfg.Name, "activePID", info.ActivePID)
+		return nil
+	}
+	if err := s.execReplicationCommand(ctx, fmt.Sprintf("ALTER_REPLICATION_SLOT %s (FAILOVER true)", s.cfg.Name)); err != nil {
+		return errors.Wrap(err, "replication slot enable failover")
+	}
+	logger.Info("replication slot failover enabled", "name", s.cfg.Name)
+	return nil
+}
+
+// scalarLocked runs sql on the regular connection and returns the first
+// column of the first row as text.
+func (s *Slot) scalarLocked(ctx context.Context, sql string) (string, error) {
+	results, err := s.conn.Exec(ctx, sql).ReadAll()
+	if err != nil {
+		return "", err
+	}
+	if len(results) == 0 || len(results[0].Rows) == 0 || len(results[0].Rows[0]) == 0 {
+		return "", errors.Newf("no rows: %s", sql)
+	}
+	return string(results[0].Rows[0][0]), nil
+}
+
+// execReplicationCommand runs a replication-protocol command
+// (CREATE_REPLICATION_SLOT, ALTER_REPLICATION_SLOT) on a short-lived
+// replication connection.
+func (s *Slot) execReplicationCommand(ctx context.Context, sql string) error {
 	if err := s.replicationConn.Connect(ctx); err != nil {
 		return errors.Wrap(err, "slot replication connect")
 	}
@@ -99,17 +175,13 @@ func (s *Slot) createSlotWithReplicationConn(ctx context.Context) error {
 		_ = s.replicationConn.Close(ctx)
 	}()
 
-	sql := fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL pgoutput", s.cfg.Name)
 	resultReader := s.replicationConn.Exec(ctx, sql)
-	_, err := resultReader.ReadAll()
-	if err != nil {
-		return errors.Wrap(err, "replication slot create result")
+	if _, err := resultReader.ReadAll(); err != nil {
+		return errors.Wrap(err, "result")
 	}
-
-	if err = resultReader.Close(); err != nil {
-		return errors.Wrap(err, "replication slot create result reader close")
+	if err := resultReader.Close(); err != nil {
+		return errors.Wrap(err, "result reader close")
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Step 3 of `docs/visibility-gate-design.md` (P6). Stacked on #168 (`feature/commit-lsn`); retarget once the chain below merges.

## What

- `slot.failover: true` (default `false`):
  - fresh slot: `CREATE_REPLICATION_SLOT <name> LOGICAL pgoutput (FAILOVER true)`
  - existing slot with `pg_replication_slots.failover = false`: `ALTER_REPLICATION_SLOT <name> (FAILOVER true)`
  - servers older than 17: rejected before any replication command via `SHOW server_version_num`, error `slot.failover requires PostgreSQL 17 or newer (server_version_num N)`.
- `createSlotWithReplicationConn` became `execReplicationCommand(sql)` so CREATE and ALTER share the short-lived replication connection.
- README: `slot.failover` config row and a "Failover slots (PostgreSQL 17+)" section: `synchronized_standby_slots` on the primary (empty = no waiting), standby requirements (`sync_replication_slots`, `hot_standby_feedback`, `primary_slot_name`, `dbname` in `primary_conninfo`), the inactive-listed-slot stall, Patroni 4.1.0+ leaving failover slots alone but not setting the GUC.
- CI: `17-alpine` added to the integration matrix so the CREATE/ALTER path runs in CI, not only the reject path.

## One refinement, flagged

`ALTER_REPLICATION_SLOT` fails while another walsender holds the slot. During a rolling deployment the new instance's `Create` runs while the old one is still active, so in that case the ALTER is **skipped with a warning** and retried by the next `Create` (`Start` re-runs it after every failed capture). If the old instance releases the slot between `Create` and `START_REPLICATION`, failover gets enabled on the next restart; the warning says so. Not a circuit breaker or a second knob, just "do not crash the standby instance on a command that cannot succeed yet".

## Tests

`integration_test/slot_failover_test.go`, run locally:

| server | path | result |
|---|---|---|
| `postgres:16-alpine` | reject with clear error | pass |
| `postgres:17-alpine` | create with FAILOVER, ALTER an existing slot, idempotent re-run | pass |
| `postgres:17-alpine` | full integration suite (71 tests) | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124R4t7he2DYPLKsrEd8Enj
