### PR TITLE
docs(readme): visibility guard mechanism, guarantee limits, sync-rep corollary

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ ensuring low resource consumption and high performance.
 		- [Configuration](#configuration)
 		- [Protocol Version \& Streaming Transactions](#protocol-version--streaming-transactions)
 		- [API](#api)
+		- [Visibility Guard](#visibility-guard)
+		- [Commit LSN and reading from a standby](#commit-lsn-and-reading-from-a-standby)
+		- [Failover slots (PostgreSQL 17+)](#failover-slots-postgresql-17)
 		- [Exposed Metrics](#exposed-metrics)
 		- [Grafana Dashboard](#grafana-dashboard)
 		- [Compatibility](#compatibility)
@@ -392,7 +395,7 @@ You can run [Replica Identity Nothing](./example/replica-identity-nothing) for a
 | `heartbeat.table.schema`                |  string  |    no    | public  | Schema of the heartbeat table.                                                                          | Defaults to `public` when omitted.                                                                            |
 | `heartbeat.interval`                    | duration |    no    | 100ms   | Interval between heartbeat updates when heartbeat is configured. Must be greater than 0.               | Any valid Go duration string (e.g. `100ms`, `1s`, `5s`, `1m`).                                                |
 | `extensionSupport.enableTimescaleDB`    |   bool   |    no    |  false  | Enable support for TimescaleDB hypertables. Ensures proper handling of compressed chunks during replication. |                                                                                                                                                    |
-| `visibilityGuard.enabled`               |   bool   |    no    |  false  | Hold the first event of every transaction until the transaction is visible to new snapshots on the primary (closes the logical-decoding read-after-write window; see `docs/visibility-gate-design.md`). | Opens one extra regular connection to the same host as the replication connection. Heartbeat events bypass the gate.                                |
+| `visibilityGuard.enabled`               |   bool   |    no    |  false  | Hold the first event of every transaction until the transaction is visible to new snapshots on the primary (closes the logical-decoding read-after-write window; see [Visibility Guard](#visibility-guard)). | Opens one extra regular connection to the same host as the replication connection. Heartbeat events bypass the gate.                                |
 | `visibilityGuard.failMode`              |  string  |    no    | closed  | What to do when a transaction is not visible within `timeout`                                          | **closed:** restart the stream; the event is redelivered from the confirmed LSN. **open:** log a warning, count it, dispatch anyway. Guard errors (replica, failover, connection loss) restart the stream in both modes. |
 | `visibilityGuard.timeout`               | duration |    no    |  10s    | Maximum time to wait per transaction                                                                   | Must be less than half of the server's `wal_sender_timeout` (checked at startup, skipped when it is `0`): keepalive replies stop while the gate blocks. |
 | `visibilityGuard.pollInterval`          | duration |    no    |  5ms    | First poll interval; doubles up to 250ms with jitter                                                   |                                                                                                                                                    |
@@ -426,6 +429,61 @@ Streaming behavior for `proto_version: 2`:
 - Events are emitted only on `STREAM COMMIT`.
 - `STREAM ABORT` discards all buffered events for that transaction.
 - This prevents rolled-back streamed transactions from leaking to consumers.
+
+### Visibility Guard
+
+**Mechanism.** The logical walsender streams a transaction as soon as its commit record is flushed to WAL. The rows
+become visible to new snapshots only later, when the committing backend finishes (`ProcArrayEndTransaction`), and with
+`synchronous_standby_names` set (Patroni `synchronous_mode`) that step first waits for the synchronous standby's
+acknowledgement. A consumer that receives the event and immediately reads the primary can therefore miss the row
+(read-after-write); the same ordering allows a "phantom" event if the primary dies before the standby received the
+commit. `visibilityGuard` closes this window: before dispatching the first event of every transaction it polls a
+regular connection on the same host until the transaction's xid is no longer in progress in `pg_current_snapshot()`
+(`txid_current_snapshot()` before PostgreSQL 13). Later events of the same transaction pass without a wait; heartbeat
+events bypass the gate.
+
+```yaml
+visibilityGuard:
+  enabled: true
+  failMode: closed   # closed | open
+  timeout: 10s       # must be < wal_sender_timeout / 2
+  pollInterval: 5ms  # doubles up to 250ms, with jitter
+```
+
+**Guarantee.** Everything delivered to the handler is committed on the server (with or without the guard). With the
+guard on, a fresh snapshot taken on the same primary after the handler was called also sees the row.
+
+**Limits.** The guarantee does not cover:
+
+- Reads from a standby, or through a pooler that may route to one. Use the strict `CommitLSN` rule in
+  [Commit LSN and reading from a standby](#commit-lsn-and-reading-from-a-standby). In Patroni deployments this is the
+  more likely cause of "the row is not there yet" than the primary-side window.
+- The consumer's own open `REPEATABLE READ` or `SERIALIZABLE` transaction: its snapshot predates the commit.
+- Later changes: the row may already be updated or deleted when the consumer reads it.
+- Row-level security and the privileges of the reading role.
+
+Consumer-side retry and self-contained outbox payloads remain the recommended pattern; the guard removes the common
+case, not the need for them.
+
+**Failure handling.** `failMode: closed` (default): a timeout or any guard error (server in recovery, timeline changed,
+connection lost) restarts the stream with the error class `visibility guard unreachable`; the held event is not acked
+and is redelivered from the confirmed LSN. `failMode: open`: after `timeout` the event is dispatched with a warning and
+`go_pq_cdc_visibility_fail_open_total` is incremented; guard errors still restart the stream. `timeout` must stay below
+half of the server's `wal_sender_timeout` (checked at startup, skipped when it is `0`) because keepalive replies stop
+while the gate blocks. Waits are recorded in `go_pq_cdc_visibility_wait_duration_seconds`, timeouts in
+`go_pq_cdc_visibility_timeout_total`.
+
+**Synchronous replication corollary.** With `synchronous_standby_names` set, a transaction becomes visible on the
+primary only after the synchronous standby acknowledged it at the configured `synchronous_commit` level. A fail-closed
+guard therefore also prevents phantom events on a Patroni failover, without PostgreSQL 17 failover slots: an event is
+dispatched only once the standby that may be promoted has the commit. This holds unless:
+
+- Patroni runs `synchronous_mode` without `synchronous_mode_strict` and no standby is available: synchronous
+  replication is switched off and commits stop waiting.
+- The committing backend is cancelled or terminated while waiting for the standby: it commits locally and becomes
+  visible without the acknowledgement (the server logs a WARNING).
+- The session used `synchronous_commit = local` or `off`.
+- `synchronous_commit = remote_write`: the standby received the WAL but has not flushed it.
 
 ### Commit LSN and reading from a standby
 

--- a/docs/visibility-gate-design.md
+++ b/docs/visibility-gate-design.md
@@ -1,6 +1,6 @@
 # Visibility gate — implementation handoff
 
-Status: **design agreed, not implemented.** Decided 2026-09-03 by a three-round consensus between Codex, Claude Opus 4.8 and Claude Fable 5.1, each verifying claims against PostgreSQL `master` sources. Full report (mechanism, verdict tables, decisions): https://claude.ai/code/artifact/555f3849-212d-4de4-ad33-0a10d01eb93d
+Status: **implemented** (PRs #166–#169 and the README sections "Visibility Guard", "Commit LSN and reading from a standby", "Failover slots"); kept as the design record. Decided 2026-09-03 by a three-round consensus between Codex, Claude Opus 4.8 and Claude Fable 5.1, each verifying claims against PostgreSQL `master` sources. Full report (mechanism, verdict tables, decisions): https://claude.ai/code/artifact/555f3849-212d-4de4-ad33-0a10d01eb93d
 
 ## Problem in two sentences
 

--- a/example/visibility-guard/README.md
+++ b/example/visibility-guard/README.md
@@ -1,0 +1,165 @@
+# Visibility Guard Lab
+
+A hands-on tour of three features on PostgreSQL 17: `visibilityGuard`, `ctx.CommitLSN` and `slot.failover`.
+The consumer in `main.go` plays a downstream service: for every insert event it opens a fresh snapshot on the
+primary and reports **VISIBLE** (the row is there) or **MISS** (the event arrived before the row is visible).
+
+## The window, in one paragraph
+
+When a transaction commits, PostgreSQL first writes the commit record to WAL and flushes it. At that moment the
+logical walsender already sends the change to go-pq-cdc. Only afterwards does the committing backend mark the
+transaction as finished so that new snapshots can see its rows. Normally that gap is microseconds. With
+synchronous replication (Patroni `synchronous_mode`) the backend waits for the standby's acknowledgement between
+those two steps, so the gap grows to a network round-trip, and a consumer that reads the primary right after the
+event can miss the row.
+
+This lab makes the gap infinite on purpose: `synchronous_standby_names = 'ghost'` makes every commit wait for a
+standby that does not exist. The WAL is flushed, the event is sent, the row stays invisible until you release it.
+
+## Setup
+
+```bash
+cd example/visibility-guard
+docker compose up -d --wait   # PostgreSQL 17 on port 5436 (5432-5435 are often taken)
+go run .                      # guard off
+```
+
+`./lab.sh` runs all six steps below unattended in about 30 seconds and prints what it saw; the manual walk-through
+is where the learning is.
+
+In a second terminal, open a psql session inside the container:
+
+```bash
+docker compose exec postgres psql -U cdc_user -d cdc_db
+```
+
+> Start the consumer **before** freezing commits. Creating the publication and the slot are commits too, and they
+> would hang.
+
+## 1. Guard off: see the MISS
+
+```sql
+INSERT INTO orders (note) VALUES ('normal');          -- consumer logs VISIBLE
+ALTER SYSTEM SET synchronous_standby_names = 'ghost';
+SELECT pg_reload_conf();                               -- from now on every commit waits forever
+INSERT INTO orders (note) VALUES ('frozen');          -- this statement hangs, that is the point
+```
+
+The consumer logs:
+
+```
+INFO VISIBLE id=1 note=normal commitLSN=0/192E498 walNow=0/192E4C8
+WARN MISS: event received but row not visible yet id=2 note=frozen commitLSN=0/192E558 walNow=0/192E588
+```
+
+In a third psql session `SELECT * FROM orders WHERE note = 'frozen'` returns nothing: the event exists, the row
+does not (yet).
+
+Release the commit:
+
+```sql
+ALTER SYSTEM RESET synchronous_standby_names;
+SELECT pg_reload_conf();                               -- the hanging INSERT returns, the row is visible
+```
+
+## 2. Guard on, `failMode: closed` (default)
+
+```bash
+go run . -guard -timeout 5s
+```
+
+```sql
+ALTER SYSTEM SET synchronous_standby_names = 'ghost';
+SELECT pg_reload_conf();
+INSERT INTO orders (note) VALUES ('frozen-closed');
+```
+
+Freeze and insert again. Nothing reaches the handler: the guard polls `pg_current_snapshot()` and the transaction
+is still in progress. After `timeout` the process logs `visibility guard failed, restarting stream` with the error
+class `visibility guard unreachable` and **exits** (the same crash-and-restart path as a lost replication
+connection; in production your orchestrator restarts it). The event was never acked, so it is redelivered on the
+next start. Release the commit, run the consumer again: the row arrives as VISIBLE.
+
+```
+ERROR visibility guard failed, restarting stream error="visibility guard unreachable: visibility guard timeout: xid 744 not visible after 5s"
+(process exits; release; start again)
+INFO VISIBLE id=3 note=frozen-closed commitLSN=0/192E620 walNow=0/192E688
+```
+
+Closed means "never hand out an event I cannot certify". The price is a restart loop while the primary is stuck,
+which is what you want to be alerted on.
+
+## 3. Guard on, `failMode: open`
+
+```bash
+go run . -guard -fail-mode open -timeout 3s
+```
+
+```sql
+ALTER SYSTEM SET synchronous_standby_names = 'ghost';
+SELECT pg_reload_conf();
+INSERT INTO orders (note) VALUES ('frozen-closed-v2');
+```
+
+Freeze and insert. After `timeout` the consumer logs `visibility guard timeout, dispatching anyway (failMode: open)`
+followed by the MISS, and keeps running. Check the counters:
+
+```bash
+curl -s localhost:8081/metrics | grep visibility
+```
+
+```
+WARN visibility guard timeout, dispatching anyway (failMode: open) xid=745
+WARN MISS: event received but row not visible yet id=4 note=frozen-open ...
+go_pq_cdc_visibility_timeout_total{...} 1
+go_pq_cdc_visibility_fail_open_total{...} 1
+```
+
+Open means "prefer latency over certainty and tell me about it". Release the commit when done.
+
+## 4. Caveat: sessions that skip the wait
+
+```sql
+SET synchronous_commit = off;
+INSERT INTO orders (note) VALUES ('async');           -- returns immediately even while frozen
+```
+
+The row is visible at once and the guard lets the event through: the session opted out of the standby wait, so
+"visible on the primary" no longer implies "acknowledged by the standby". This is the first caveat of the
+synchronous-replication corollary in the README; `pg_cancel_backend(<pid of a hanging INSERT>)` demonstrates the
+second one (the transaction commits locally and becomes visible without the acknowledgement).
+
+## 5. `ctx.CommitLSN`
+
+Every VISIBLE/MISS line prints `commitLSN` (the transaction's commit record) next to `walNow`
+(`pg_current_wal_lsn()` at read time). On a standby the read rule is strict:
+
+```sql
+SELECT pg_last_wal_replay_lsn() > '<commitLSN>'::pg_lsn;
+```
+
+`pg_last_wal_replay_lsn()` is the end of the last replayed record, so it equals `commitLSN` just before the
+commit record is applied; `>=` would pass too early.
+
+## 6. Failover slot
+
+Stop the consumer (the slot must be inactive for `ALTER_REPLICATION_SLOT`), then:
+
+```bash
+go run . -failover
+```
+
+```sql
+SELECT slot_name, failover FROM pg_replication_slots;  -- cdc_slot | t
+```
+
+The existing slot was altered; a fresh slot would be created with `FAILOVER true`. Switch the image in
+`docker-compose.yml` to `postgres:16-alpine` and the same flag fails at startup with
+`slot.failover requires PostgreSQL 17 or newer`. A failover slot only pays off with a standby running
+`sync_replication_slots` and `synchronized_standby_slots` set on the primary; see the main README.
+
+## Cleanup
+
+```bash
+docker compose down -v
+```

--- a/example/visibility-guard/docker-compose.yml
+++ b/example/visibility-guard/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: cdc_db
+      POSTGRES_USER: cdc_user
+      POSTGRES_PASSWORD: cdc_pass
+    ports:
+      - "5436:5432"
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+      - -c
+      - max_replication_slots=20
+      - -c
+      - max_wal_senders=25
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U cdc_user -d cdc_db" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/example/visibility-guard/init.sql
+++ b/example/visibility-guard/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE orders (
+   id serial PRIMARY KEY,
+   note text NOT NULL,
+   created_at timestamptz DEFAULT now()
+);

--- a/example/visibility-guard/lab.sh
+++ b/example/visibility-guard/lab.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Runs the six README steps unattended against the docker-compose PostgreSQL 17.
+# Needs: docker compose, go, curl. Prints one or two lines per step.
+set -eu
+cd "$(dirname "$0")"
+BIN=$(mktemp -d)/vg
+LOG=$(mktemp -d)
+docker compose up -d --wait >/dev/null 2>&1
+go build -o "$BIN" .
+psql()    { docker compose exec -T postgres psql -U cdc_user -d cdc_db -Atc "$1"; }
+waitlog() { i=0; until grep -q "$2" "$1"; do i=$((i+1)); [ $i -gt 80 ] && { echo "timeout waiting for '$2'"; return 1; }; sleep 0.5; done; }
+freeze()  { psql "ALTER SYSTEM SET synchronous_standby_names = 'ghost'" >/dev/null; psql "SELECT pg_reload_conf()" >/dev/null; }
+release() { psql "ALTER SYSTEM RESET synchronous_standby_names" >/dev/null; psql "SELECT pg_reload_conf()" >/dev/null; }
+start()   { "$BIN" "$@" > "$LOG/cur.log" 2>&1 & PID=$!; waitlog "$LOG/cur.log" "slot captured"; }
+stop()    { kill $PID 2>/dev/null; wait $PID 2>/dev/null || true; }
+insert()  { psql "INSERT INTO orders (note) VALUES ('$1')" >/dev/null & INS=$!; }
+
+echo "## 1. guard off"
+start
+psql "INSERT INTO orders (note) VALUES ('normal')" >/dev/null; waitlog "$LOG/cur.log" VISIBLE; grep VISIBLE "$LOG/cur.log" | tail -1
+freeze; insert frozen; waitlog "$LOG/cur.log" MISS; grep MISS "$LOG/cur.log" | tail -1
+echo "rows visible to a fresh session while frozen: $(psql "SELECT count(*) FROM orders WHERE note = 'frozen'")"
+release; wait $INS; stop
+
+echo "## 2. guard on, failMode closed"
+start -guard -timeout 5s
+freeze; insert frozen-closed; waitlog "$LOG/cur.log" "visibility guard failed"; grep "visibility guard failed" "$LOG/cur.log" | tail -1
+wait $PID 2>/dev/null || echo "consumer exited, event not acked"
+release; wait $INS
+start -guard -timeout 5s; waitlog "$LOG/cur.log" frozen-closed; grep frozen-closed "$LOG/cur.log" | tail -1; stop
+
+echo "## 3. guard on, failMode open"
+start -guard -fail-mode open -timeout 3s
+freeze; insert frozen-open; waitlog "$LOG/cur.log" MISS; grep -E "dispatching anyway|MISS" "$LOG/cur.log" | tail -2
+curl -s localhost:8081/metrics | grep -E "^go_pq_cdc_visibility_(timeout|fail_open)_total"
+release; wait $INS; stop
+
+echo "## 4. caveat: synchronous_commit = off"
+start -guard -timeout 5s
+freeze; psql "SET synchronous_commit = off; INSERT INTO orders (note) VALUES ('async')" >/dev/null
+waitlog "$LOG/cur.log" async; grep async "$LOG/cur.log" | tail -1
+release; stop
+
+echo "## 5. CommitLSN: compare commitLSN with walNow in the lines above"
+
+echo "## 6. failover slot"
+echo "before: $(psql "SELECT failover FROM pg_replication_slots WHERE slot_name = 'cdc_slot'")"
+start -failover; stop
+echo "after:  $(psql "SELECT failover FROM pg_replication_slots WHERE slot_name = 'cdc_slot'")"
+
+docker compose down -v >/dev/null 2>&1
+echo "done"

--- a/example/visibility-guard/main.go
+++ b/example/visibility-guard/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"os"
+	"time"
+
+	cdc "github.com/Trendyol/go-pq-cdc"
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/Trendyol/go-pq-cdc/pq/publication"
+	"github.com/Trendyol/go-pq-cdc/pq/replication"
+	"github.com/Trendyol/go-pq-cdc/pq/slot"
+	"github.com/jackc/pgx/v5"
+)
+
+// The handler plays a downstream service: for every insert event it opens a
+// fresh snapshot on the primary and checks whether the row is there yet.
+// VISIBLE is what you expect; MISS is the read-after-write window. See README.md.
+func main() {
+	guard := flag.Bool("guard", false, "enable visibilityGuard")
+	failMode := flag.String("fail-mode", "closed", "visibilityGuard.failMode: closed | open")
+	timeout := flag.Duration("timeout", 10*time.Second, "visibilityGuard.timeout (must be < wal_sender_timeout/2)")
+	failover := flag.Bool("failover", false, "slot.failover (PostgreSQL 17+)")
+	flag.Parse()
+
+	ctx := context.Background()
+	cfg := config.Config{
+		Host:     "127.0.0.1",
+		Port:     5436,
+		Username: "cdc_user",
+		Password: "cdc_pass",
+		Database: "cdc_db",
+		Publication: publication.Config{
+			CreateIfNotExists: true,
+			Name:              "cdc_publication",
+			Operations:        publication.Operations{publication.OperationInsert},
+			Tables: publication.Tables{
+				{Name: "orders", Schema: "public", ReplicaIdentity: publication.ReplicaIdentityDefault},
+			},
+		},
+		Slot: slot.Config{
+			CreateIfNotExists:           true,
+			Name:                        "cdc_slot",
+			SlotActivityCheckerInterval: 3000,
+			Failover:                    *failover,
+		},
+		VisibilityGuard: config.VisibilityGuardConfig{
+			Enabled:  *guard,
+			FailMode: config.VisibilityFailMode(*failMode),
+			Timeout:  *timeout,
+		},
+		Metric: config.MetricConfig{Port: 8081},
+		Logger: config.LoggerConfig{LogLevel: slog.LevelInfo},
+	}
+
+	// Separate autocommit connection: each query takes a fresh snapshot,
+	// exactly what a service reading the primary right after the event would see.
+	reader, err := pgx.Connect(ctx, cfg.DSNWithoutSSL())
+	if err != nil {
+		slog.Error("reader connect", "error", err)
+		os.Exit(1)
+	}
+	defer reader.Close(ctx)
+
+	handler := func(lCtx *replication.ListenerContext) {
+		if ins, ok := lCtx.Message.(*format.Insert); ok {
+			id := ins.Decoded["id"]
+			var visible bool
+			var walNow string
+			err := reader.QueryRow(lCtx.Context,
+				"SELECT EXISTS (SELECT 1 FROM orders WHERE id = $1), pg_current_wal_lsn()::text", id,
+			).Scan(&visible, &walNow)
+			switch {
+			case err != nil:
+				slog.Error("read after event", "id", id, "error", err)
+			case visible:
+				slog.Info("VISIBLE", "id", id, "note", ins.Decoded["note"], "commitLSN", lCtx.CommitLSN.String(), "walNow", walNow)
+			default:
+				slog.Warn("MISS: event received but row not visible yet", "id", id, "note", ins.Decoded["note"], "commitLSN", lCtx.CommitLSN.String(), "walNow", walNow)
+			}
+		}
+		if err := lCtx.Ack(); err != nil {
+			slog.Error("ack", "error", err)
+		}
+	}
+
+	connector, err := cdc.NewConnector(ctx, cfg, handler)
+	if err != nil {
+		slog.Error("new connector", "error", err)
+		os.Exit(1)
+	}
+	defer connector.Close()
+	connector.Start(ctx)
+}

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -152,6 +152,11 @@ func (s *stream) Open(ctx context.Context) error {
 			return errors.Wrap(err, "visibility guard")
 		}
 		s.guard = guard
+		logger.Info("visibility guard enabled",
+			"failMode", s.config.VisibilityGuard.FailMode,
+			"timeout", s.config.VisibilityGuard.Timeout,
+			"pollInterval", s.config.VisibilityGuard.PollInterval,
+		)
 	}
 
 	s.sinkStarted.Store(true)

--- a/pq/replication/visibility.go
+++ b/pq/replication/visibility.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Trendyol/go-pq-cdc/config"
 	"github.com/Trendyol/go-pq-cdc/internal/metric"
+	"github.com/Trendyol/go-pq-cdc/logger"
 	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -143,7 +144,14 @@ func queryRow(conn pq.Connection) func(context.Context, string) ([]string, error
 // treated as "visible".
 func (g *visibilityGuard) wait(ctx context.Context, xid uint32) error {
 	start := time.Now()
-	defer func() { g.metric.ObserveVisibilityWait(time.Since(start)) }()
+	polled := false
+	defer func() {
+		waited := time.Since(start)
+		g.metric.ObserveVisibilityWait(waited)
+		if polled {
+			logger.Info("visibility guard wait completed", "xid", xid, "duration", waited)
+		}
+	}()
 
 	if g.hasSnapshot && xidPrecedes(xid, g.xmin) {
 		return nil
@@ -152,6 +160,7 @@ func (g *visibilityGuard) wait(ctx context.Context, xid uint32) error {
 	deadline := start.Add(g.cfg.Timeout)
 	delay := g.cfg.PollInterval
 	for {
+		polled = true
 		snap, err := g.poll(ctx)
 		if err != nil {
 			return err

--- a/pq/replication/visibility.go
+++ b/pq/replication/visibility.go
@@ -60,6 +60,7 @@ const (
 	legacyPollSQL       = "SELECT pg_is_in_recovery(), txid_current_snapshot()::text"         // PostgreSQL < 13
 	undefinedFunction   = "42883"
 	maxPollInterval     = 250 * time.Millisecond
+	slowVisibilityWait  = 100 * time.Millisecond
 )
 
 // openVisibilityGuard dials dsn and runs the mandatory open checks.
@@ -142,14 +143,21 @@ func queryRow(conn pq.Connection) func(context.Context, string) ([]string, error
 // ErrVisibilityTimeout after cfg.Timeout; any other error means the guard can no
 // longer certify visibility and the stream must restart. Errors are never
 // treated as "visible".
-func (g *visibilityGuard) wait(ctx context.Context, xid uint32) error {
+func (g *visibilityGuard) wait(ctx context.Context, xid uint32) (err error) {
 	start := time.Now()
-	polled := false
+	pollCount := 0
 	defer func() {
 		waited := time.Since(start)
 		g.metric.ObserveVisibilityWait(waited)
-		if polled {
-			logger.Info("visibility guard wait completed", "xid", xid, "duration", waited)
+		if err != nil || pollCount == 0 {
+			return
+		}
+
+		args := []any{"xid", xid, "wait_ms", float64(waited.Microseconds()) / 1000, "poll_count", pollCount}
+		if waited >= slowVisibilityWait {
+			logger.Info("visibility guard slow wait completed", args...)
+		} else {
+			logger.Debug("visibility guard wait completed", args...)
 		}
 	}()
 
@@ -160,7 +168,7 @@ func (g *visibilityGuard) wait(ctx context.Context, xid uint32) error {
 	deadline := start.Add(g.cfg.Timeout)
 	delay := g.cfg.PollInterval
 	for {
-		polled = true
+		pollCount++
 		snap, err := g.poll(ctx)
 		if err != nil {
 			return err


### PR DESCRIPTION
Step 4 of `docs/visibility-gate-design.md` (P5, P10). Docs only. Stacked on #169 (`feature/slot-failover`); retarget once the chain merges. P6 and P7 were documented in #168/#169, so this PR fills in what was left.

## What

New README section **Visibility Guard**, placed before "Commit LSN and reading from a standby" and "Failover slots":

- **Mechanism** in one paragraph: walsender sends at WAL flush, rows visible only after `ProcArrayEndTransaction`, sync-rep ack widens the gap, so read-after-write and phantom events are possible; what the guard does about it (first event of each transaction, `pg_current_snapshot()` / `txid_current_snapshot()`, heartbeat bypass).
- The `visibilityGuard` YAML block.
- **Guarantee** (P10): everything delivered is committed; with the guard on, a fresh snapshot on the same primary after the handler was called sees the row.
- **Limits** (P10): standby/pooler reads (pointing at the strict `CommitLSN` rule, and saying plainly this is the more likely cause in Patroni deployments), the consumer's own open `REPEATABLE READ`/`SERIALIZABLE` snapshot, later updates/deletes, RLS/privileges. Retry and self-contained outbox payloads remain recommended.
- **Failure handling** per `failMode`, the `wal_sender_timeout / 2` rule and why, and the three metrics.
- **Synchronous replication corollary** (P5) with its caveats: Patroni non-strict mode switching sync off, cancel/terminate during the standby wait committing locally, `synchronous_commit = local/off`, `remote_write` being receipt rather than flush.

Also: table-of-contents entries for the three sections, the `visibilityGuard.enabled` config row links to the section, and the design doc's status line says "implemented, kept as the design record" instead of "not implemented".

