### PR TITLE
feat: logical decoding improvements

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ "15-alpine",  "15.7-alpine", "16-alpine", "16.3-alpine" ]
+        version: [ "15-alpine",  "15.7-alpine", "16-alpine", "16.3-alpine", "17-alpine" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ ensuring low resource consumption and high performance.
 		- [Configuration](#configuration)
 		- [Protocol Version \& Streaming Transactions](#protocol-version--streaming-transactions)
 		- [API](#api)
+		- [Visibility Guard](#visibility-guard)
+		- [Commit LSN and reading from a standby](#commit-lsn-and-reading-from-a-standby)
+		- [Failover slots (PostgreSQL 17+)](#failover-slots-postgresql-17)
 		- [Exposed Metrics](#exposed-metrics)
 		- [Grafana Dashboard](#grafana-dashboard)
 		- [Compatibility](#compatibility)
@@ -392,7 +395,7 @@ You can run [Replica Identity Nothing](./example/replica-identity-nothing) for a
 | `heartbeat.table.schema`                |  string  |    no    | public  | Schema of the heartbeat table.                                                                          | Defaults to `public` when omitted.                                                                            |
 | `heartbeat.interval`                    | duration |    no    | 100ms   | Interval between heartbeat updates when heartbeat is configured. Must be greater than 0.               | Any valid Go duration string (e.g. `100ms`, `1s`, `5s`, `1m`).                                                |
 | `extensionSupport.enableTimescaleDB`    |   bool   |    no    |  false  | Enable support for TimescaleDB hypertables. Ensures proper handling of compressed chunks during replication. |                                                                                                                                                    |
-| `visibilityGuard.enabled`               |   bool   |    no    |  false  | Hold the first event of every transaction until the transaction is visible to new snapshots on the primary (closes the logical-decoding read-after-write window; see `docs/visibility-gate-design.md`). | Opens one extra regular connection to the same host as the replication connection. Heartbeat events bypass the gate.                                |
+| `visibilityGuard.enabled`               |   bool   |    no    |  false  | Hold the first event of every transaction until the transaction is visible to new snapshots on the primary (closes the logical-decoding read-after-write window; see [Visibility Guard](#visibility-guard)). | Opens one extra regular connection to the same host as the replication connection. Heartbeat events bypass the gate.                                |
 | `visibilityGuard.failMode`              |  string  |    no    | closed  | What to do when a transaction is not visible within `timeout`                                          | **closed:** restart the stream; the event is redelivered from the confirmed LSN. **open:** log a warning, count it, dispatch anyway. Guard errors (replica, failover, connection loss) restart the stream in both modes. |
 | `visibilityGuard.timeout`               | duration |    no    |  10s    | Maximum time to wait per transaction                                                                   | Must be less than half of the server's `wal_sender_timeout` (checked at startup, skipped when it is `0`): keepalive replies stop while the gate blocks. |
 | `visibilityGuard.pollInterval`          | duration |    no    |  5ms    | First poll interval; doubles up to 250ms with jitter                                                   |                                                                                                                                                    |
@@ -426,6 +429,61 @@ Streaming behavior for `proto_version: 2`:
 - Events are emitted only on `STREAM COMMIT`.
 - `STREAM ABORT` discards all buffered events for that transaction.
 - This prevents rolled-back streamed transactions from leaking to consumers.
+
+### Visibility Guard
+
+**Mechanism.** The logical walsender streams a transaction as soon as its commit record is flushed to WAL. The rows
+become visible to new snapshots only later, when the committing backend finishes (`ProcArrayEndTransaction`), and with
+`synchronous_standby_names` set (Patroni `synchronous_mode`) that step first waits for the synchronous standby's
+acknowledgement. A consumer that receives the event and immediately reads the primary can therefore miss the row
+(read-after-write); the same ordering allows a "phantom" event if the primary dies before the standby received the
+commit. `visibilityGuard` closes this window: before dispatching the first event of every transaction it polls a
+regular connection on the same host until the transaction's xid is no longer in progress in `pg_current_snapshot()`
+(`txid_current_snapshot()` before PostgreSQL 13). Later events of the same transaction pass without a wait; heartbeat
+events bypass the gate.
+
+```yaml
+visibilityGuard:
+  enabled: true
+  failMode: closed   # closed | open
+  timeout: 10s       # must be < wal_sender_timeout / 2
+  pollInterval: 5ms  # doubles up to 250ms, with jitter
+```
+
+**Guarantee.** Everything delivered to the handler is committed on the server (with or without the guard). With the
+guard on, a fresh snapshot taken on the same primary after the handler was called also sees the row.
+
+**Limits.** The guarantee does not cover:
+
+- Reads from a standby, or through a pooler that may route to one. Use the strict `CommitLSN` rule in
+  [Commit LSN and reading from a standby](#commit-lsn-and-reading-from-a-standby). In Patroni deployments this is the
+  more likely cause of "the row is not there yet" than the primary-side window.
+- The consumer's own open `REPEATABLE READ` or `SERIALIZABLE` transaction: its snapshot predates the commit.
+- Later changes: the row may already be updated or deleted when the consumer reads it.
+- Row-level security and the privileges of the reading role.
+
+Consumer-side retry and self-contained outbox payloads remain the recommended pattern; the guard removes the common
+case, not the need for them.
+
+**Failure handling.** `failMode: closed` (default): a timeout or any guard error (server in recovery, timeline changed,
+connection lost) restarts the stream with the error class `visibility guard unreachable`; the held event is not acked
+and is redelivered from the confirmed LSN. `failMode: open`: after `timeout` the event is dispatched with a warning and
+`go_pq_cdc_visibility_fail_open_total` is incremented; guard errors still restart the stream. `timeout` must stay below
+half of the server's `wal_sender_timeout` (checked at startup, skipped when it is `0`) because keepalive replies stop
+while the gate blocks. Waits are recorded in `go_pq_cdc_visibility_wait_duration_seconds`, timeouts in
+`go_pq_cdc_visibility_timeout_total`.
+
+**Synchronous replication corollary.** With `synchronous_standby_names` set, a transaction becomes visible on the
+primary only after the synchronous standby acknowledged it at the configured `synchronous_commit` level. A fail-closed
+guard therefore also prevents phantom events on a Patroni failover, without PostgreSQL 17 failover slots: an event is
+dispatched only once the standby that may be promoted has the commit. This holds unless:
+
+- Patroni runs `synchronous_mode` without `synchronous_mode_strict` and no standby is available: synchronous
+  replication is switched off and commits stop waiting.
+- The committing backend is cancelled or terminated while waiting for the standby: it commits locally and becomes
+  visible without the acknowledgement (the server logs a WARNING).
+- The session used `synchronous_commit = local` or `off`.
+- `synchronous_commit = remote_write`: the standby received the WAL but has not flushed it.
 
 ### Commit LSN and reading from a standby
 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ You can run [Replica Identity Nothing](./example/replica-identity-nothing) for a
 | `slot.name`                             |  string  |   yes    |    -    | Set the logical replication slot name                                                                 | Should be unique and descriptive.                                                                                                                  |
 | `slot.slotActivityCheckerInterval`      |   int    |    no    |  1000   | Set the slot activity check interval time in milliseconds                                             | Specify as an integer value in milliseconds (e.g., `1000` for 1 second).                                                                           |
 | `slot.protoVersion`                     |   int    |    no    |    2    | `pgoutput` protocol version used in `START_REPLICATION`                                               | `1`: PostgreSQL 10+ compatibility, no streaming transaction protocol messages. `2`: PostgreSQL 14+, enables streaming/messages options.           |
+| `slot.failover`                         |   bool   |    no    |  false  | Create the slot with `FAILOVER true` (PostgreSQL 17+) so standbys running `sync_replication_slots` keep a synchronized copy; an existing slot is altered with `ALTER_REPLICATION_SLOT … (FAILOVER true)`. | Rejected with a clear error on older servers. Needs `synchronized_standby_slots` on the primary, see [Failover slots](#failover-slots-postgresql-17). |
 | `snapshot.enabled`                      |   bool   |    no    |  false  | Enable initial snapshot feature                                                                       | When enabled, captures existing data before starting CDC.                                                                                          |
 | `snapshot.mode`                         |  string  |    no    |  never  | Snapshot mode: `initial`, `never`, or `snapshot_only`                                                 | **initial:** Take snapshot only if no previous snapshot exists, then start CDC. <br> **never:** Skip snapshot, start CDC immediately. <br> **snapshot_only:** Take snapshot and exit (no CDC, no replication slot required). |
 | `snapshot.chunkSize`                    |  int64   |    no    |  8000   | Number of rows per chunk during snapshot                                                              | Adjust based on table size. Larger chunks = fewer chunks but more memory per chunk.                                                               |
@@ -441,6 +442,29 @@ SELECT pg_last_wal_replay_lsn() > '<ctx.CommitLSN>'::pg_lsn;
 `pg_last_wal_replay_lsn()` reports the end of the last replayed record, so it equals `CommitLSN` right before the commit
 record itself is applied; `>=` is not enough. On PostgreSQL 17+ `pg_wal_replay_wait('<ctx.CommitLSN>')` can replace
 polling, followed by the same strict check. `ctx.CommitLSN.String()` prints the `pg_lsn` text form (`X/X`).
+
+### Failover slots (PostgreSQL 17+)
+
+`slot.failover: true` creates the replication slot with `FAILOVER true`, or issues
+`ALTER_REPLICATION_SLOT … (FAILOVER true)` for an existing slot, so a standby running `sync_replication_slots` keeps a
+synchronized copy and the slot survives a failover without WAL loss. Servers older than 17 reject the option with a clear
+error. Required setup:
+
+- **Primary:** `synchronized_standby_slots = 'standby_physical_slot'`. The logical walsender then waits for the listed
+  physical slots before sending a change, so no event is delivered ahead of the standby that may become the next
+  primary. With the parameter empty there is no waiting: the synchronized slot can lag behind what consumers have already
+  seen, and those events are redelivered after failover.
+- **Standby:** `sync_replication_slots = on`, `hot_standby_feedback = on`, `primary_slot_name` set, and `dbname` in
+  `primary_conninfo`.
+- An inactive slot listed in `synchronized_standby_slots` stalls the logical walsender; remove it from the list before
+  taking that standby down for good.
+- Patroni 4.1.0+ leaves `failover = true` slots alone (no copy, no `pg_replication_slot_advance`) but does not set
+  `synchronized_standby_slots`; set it through `postgresql.parameters`.
+- If the slot is active for another process when go-pq-cdc starts (rolling deployment), the `ALTER` is skipped with a
+  warning and retried on the next start.
+
+Complementary to `visibilityGuard`: the guard closes the read-after-write window on the primary, the failover slot keeps
+the consumer position across a promotion.
 
 ### Exposed Metrics
 

--- a/README.md
+++ b/README.md
@@ -426,6 +426,22 @@ Streaming behavior for `proto_version: 2`:
 - `STREAM ABORT` discards all buffered events for that transaction.
 - This prevents rolled-back streamed transactions from leaking to consumers.
 
+### Commit LSN and reading from a standby
+
+Every CDC event exposes `ctx.CommitLSN`: the WAL position of the commit record of the transaction that produced it
+(pgoutput `Begin.FinalLSN`, or `StreamCommit.CommitLSN` for streamed transactions). Snapshot events carry `0`.
+
+`visibilityGuard` only describes the primary. A consumer that reads from a standby, or through a pooler that may route
+to one, has to wait until the standby has replayed that commit record. The rule is **strict**:
+
+```sql
+SELECT pg_last_wal_replay_lsn() > '<ctx.CommitLSN>'::pg_lsn;
+```
+
+`pg_last_wal_replay_lsn()` reports the end of the last replayed record, so it equals `CommitLSN` right before the commit
+record itself is applied; `>=` is not enough. On PostgreSQL 17+ `pg_wal_replay_wait('<ctx.CommitLSN>')` can replace
+polling, followed by the same strict check. `ctx.CommitLSN.String()` prints the `pg_lsn` text form (`X/X`).
+
 ### Exposed Metrics
 
 The client collects relevant metrics related to PostgreSQL change data capture (CDC) and makes them available at

--- a/README.md
+++ b/README.md
@@ -391,6 +391,10 @@ You can run [Replica Identity Nothing](./example/replica-identity-nothing) for a
 | `heartbeat.table.schema`                |  string  |    no    | public  | Schema of the heartbeat table.                                                                          | Defaults to `public` when omitted.                                                                            |
 | `heartbeat.interval`                    | duration |    no    | 100ms   | Interval between heartbeat updates when heartbeat is configured. Must be greater than 0.               | Any valid Go duration string (e.g. `100ms`, `1s`, `5s`, `1m`).                                                |
 | `extensionSupport.enableTimescaleDB`    |   bool   |    no    |  false  | Enable support for TimescaleDB hypertables. Ensures proper handling of compressed chunks during replication. |                                                                                                                                                    |
+| `visibilityGuard.enabled`               |   bool   |    no    |  false  | Hold the first event of every transaction until the transaction is visible to new snapshots on the primary (closes the logical-decoding read-after-write window; see `docs/visibility-gate-design.md`). | Opens one extra regular connection to the same host as the replication connection. Heartbeat events bypass the gate.                                |
+| `visibilityGuard.failMode`              |  string  |    no    | closed  | What to do when a transaction is not visible within `timeout`                                          | **closed:** restart the stream; the event is redelivered from the confirmed LSN. **open:** log a warning, count it, dispatch anyway. Guard errors (replica, failover, connection loss) restart the stream in both modes. |
+| `visibilityGuard.timeout`               | duration |    no    |  10s    | Maximum time to wait per transaction                                                                   | Must be less than half of the server's `wal_sender_timeout` (checked at startup, skipped when it is `0`): keepalive replies stop while the gate blocks. |
+| `visibilityGuard.pollInterval`          | duration |    no    |  5ms    | First poll interval; doubles up to 250ms with jitter                                                   |                                                                                                                                                    |
 
 ### API
 
@@ -447,6 +451,9 @@ the `/metrics` endpoint.
 | go_pq_cdc_snapshot_completed_chunks                 | Number of chunks completed in snapshot.                                                                | slot_name, host| Gauge      |
 | go_pq_cdc_snapshot_total_rows                       | Total number of rows read during snapshot.                                                             | slot_name, host| Counter    |
 | go_pq_cdc_snapshot_duration_seconds                 | Duration of the last snapshot operation in seconds.                                                    | slot_name, host| Gauge      |
+| go_pq_cdc_visibility_wait_duration_seconds          | Time the visibility guard held a transaction until it became visible on the primary.                   | slot_name, host| Histogram  |
+| go_pq_cdc_visibility_timeout_total                  | Number of visibility guard waits that reached `visibilityGuard.timeout`.                               | slot_name, host| Counter    |
+| go_pq_cdc_visibility_fail_open_total                | Number of transactions dispatched after a visibility guard timeout (`failMode: open`).                 | slot_name, host| Counter    |
 | runtime metrics                                     | [Prometheus Collector](https://golang.bg/src/runtime/metrics/description.go)                          | N/A            | N/A        |
 
 ### Grafana Dashboard

--- a/config/config.go
+++ b/config/config.go
@@ -17,19 +17,56 @@ import (
 const defaultSchema = "public"
 
 type Config struct {
-	Logger           LoggerConfig       `json:"logger" yaml:"logger"`
-	Host             string             `json:"host" yaml:"host"`
-	Username         string             `json:"username" yaml:"username"`
-	Password         string             `json:"password" yaml:"password"`
-	Database         string             `json:"database" yaml:"database"`
-	Publication      publication.Config `json:"publication" yaml:"publication"`
-	Heartbeat        HeartbeatConfig    `json:"heartbeat" yaml:"heartbeat"`
-	Slot             slot.Config        `json:"slot" yaml:"slot"`
-	Snapshot         SnapshotConfig     `json:"snapshot" yaml:"snapshot"`
-	Port             int                `json:"port" yaml:"port"`
-	Metric           MetricConfig       `json:"metric" yaml:"metric"`
-	DebugMode        bool               `json:"debugMode" yaml:"debugMode"`
-	ExtensionSupport ExtensionSupport   `json:"extensionSupport" yaml:"extensionSupport"`
+	Logger           LoggerConfig          `json:"logger" yaml:"logger"`
+	Host             string                `json:"host" yaml:"host"`
+	Username         string                `json:"username" yaml:"username"`
+	Password         string                `json:"password" yaml:"password"`
+	Database         string                `json:"database" yaml:"database"`
+	Publication      publication.Config    `json:"publication" yaml:"publication"`
+	Heartbeat        HeartbeatConfig       `json:"heartbeat" yaml:"heartbeat"`
+	Slot             slot.Config           `json:"slot" yaml:"slot"`
+	VisibilityGuard  VisibilityGuardConfig `json:"visibilityGuard" yaml:"visibilityGuard"`
+	Snapshot         SnapshotConfig        `json:"snapshot" yaml:"snapshot"`
+	Port             int                   `json:"port" yaml:"port"`
+	Metric           MetricConfig          `json:"metric" yaml:"metric"`
+	DebugMode        bool                  `json:"debugMode" yaml:"debugMode"`
+	ExtensionSupport ExtensionSupport      `json:"extensionSupport" yaml:"extensionSupport"`
+}
+
+// VisibilityGuardConfig holds the first message of every transaction until the
+// transaction is visible to new snapshots on the primary. See
+// docs/visibility-gate-design.md.
+type VisibilityGuardConfig struct {
+	FailMode     VisibilityFailMode `json:"failMode" yaml:"failMode"`
+	Timeout      time.Duration      `json:"timeout" yaml:"timeout"`
+	PollInterval time.Duration      `json:"pollInterval" yaml:"pollInterval"`
+	Enabled      bool               `json:"enabled" yaml:"enabled"`
+}
+
+type VisibilityFailMode string
+
+const (
+	// VisibilityFailClosed restarts the stream on a timeout or guard error; the message is redelivered.
+	VisibilityFailClosed VisibilityFailMode = "closed"
+	// VisibilityFailOpen logs a warning and dispatches anyway on a timeout; guard errors still restart the stream.
+	VisibilityFailOpen VisibilityFailMode = "open"
+)
+
+func (v *VisibilityGuardConfig) Validate() error {
+	if !v.Enabled {
+		return nil
+	}
+	var err error
+	if v.FailMode != VisibilityFailClosed && v.FailMode != VisibilityFailOpen {
+		err = errors.Join(err, errors.New("visibilityGuard.failMode must be 'closed' or 'open'"))
+	}
+	if v.Timeout <= 0 {
+		err = errors.Join(err, errors.New("visibilityGuard.timeout must be greater than 0"))
+	}
+	if v.PollInterval <= 0 {
+		err = errors.Join(err, errors.New("visibilityGuard.pollInterval must be greater than 0"))
+	}
+	return err
 }
 
 type MetricConfig struct {
@@ -95,6 +132,18 @@ func (c *Config) SetDefault() {
 
 	if c.Logger.Logger == nil {
 		c.Logger.Logger = logger.NewSlog(c.Logger.LogLevel)
+	}
+
+	if c.VisibilityGuard.Enabled {
+		if c.VisibilityGuard.FailMode == "" {
+			c.VisibilityGuard.FailMode = VisibilityFailClosed
+		}
+		if c.VisibilityGuard.Timeout == 0 {
+			c.VisibilityGuard.Timeout = 10 * time.Second
+		}
+		if c.VisibilityGuard.PollInterval == 0 {
+			c.VisibilityGuard.PollInterval = 5 * time.Millisecond
+		}
 	}
 
 	// Set default schema names for tables
@@ -252,6 +301,10 @@ func (c *Config) Validate() error {
 		}
 
 		if cErr := c.Slot.Validate(); cErr != nil {
+			err = errors.Join(err, cErr)
+		}
+
+		if cErr := c.VisibilityGuard.Validate(); cErr != nil {
 			err = errors.Join(err, cErr)
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -636,3 +636,37 @@ func TestValidateHeartbeatInPublication(t *testing.T) {
 		assert.Contains(t, err.Error(), `publication "pub"`)
 	})
 }
+
+func TestVisibilityGuardConfig(t *testing.T) {
+	t.Run("disabled needs nothing", func(t *testing.T) {
+		cfg := Config{}
+		cfg.SetDefault()
+		require.NoError(t, cfg.VisibilityGuard.Validate())
+		assert.Equal(t, VisibilityGuardConfig{}, cfg.VisibilityGuard)
+	})
+
+	t.Run("enabled gets closed/10s/5ms defaults", func(t *testing.T) {
+		cfg := Config{VisibilityGuard: VisibilityGuardConfig{Enabled: true}}
+		cfg.SetDefault()
+		assert.Equal(t, VisibilityGuardConfig{Enabled: true, FailMode: VisibilityFailClosed, Timeout: 10 * time.Second, PollInterval: 5 * time.Millisecond}, cfg.VisibilityGuard)
+		require.NoError(t, cfg.VisibilityGuard.Validate())
+	})
+
+	t.Run("rejects unknown failMode and non-positive durations", func(t *testing.T) {
+		cfg := VisibilityGuardConfig{Enabled: true, FailMode: "half", Timeout: -time.Second, PollInterval: 0}
+		err := cfg.Validate()
+		require.ErrorContains(t, err, "failMode")
+		require.ErrorContains(t, err, "timeout")
+		require.ErrorContains(t, err, "pollInterval")
+	})
+
+	t.Run("wired into Config.Validate", func(t *testing.T) {
+		cfg := Config{
+			Host: "h", Username: "u", Password: "p", Database: "d",
+			Publication:     publication.Config{Name: "pub", Tables: publication.Tables{{Name: "t", Schema: "public", ReplicaIdentity: "FULL"}}, Operations: publication.Operations{publication.OperationInsert}},
+			Slot:            slot.Config{Name: "slot"},
+			VisibilityGuard: VisibilityGuardConfig{Enabled: true, FailMode: "half", Timeout: time.Second, PollInterval: time.Millisecond},
+		}
+		require.ErrorContains(t, cfg.Validate(), "visibilityGuard.failMode")
+	})
+}

--- a/docs/visibility-gate-design.md
+++ b/docs/visibility-gate-design.md
@@ -1,0 +1,102 @@
+# Visibility gate — implementation handoff
+
+Status: **design agreed, not implemented.** Decided 2026-09-03 by a three-round consensus between Codex, Claude Opus 4.8 and Claude Fable 5.1, each verifying claims against PostgreSQL `master` sources. Full report (mechanism, verdict tables, decisions): https://claude.ai/code/artifact/555f3849-212d-4de4-ad33-0a10d01eb93d
+
+## Problem in two sentences
+
+A logical walsender streams a transaction as soon as its commit record is flushed (`xact.c RecordTransactionCommit` → `XLogFlush` wakes walsenders), but the row becomes visible to new snapshots only after `ProcArrayEndTransaction`, which runs after `SyncRepWaitForLSN`. With Patroni `synchronous_mode` the gap is at least the standby ack round-trip, so a consumer that reads the primary right after receiving the CDC event can miss the row (read-after-write); the same ordering also allows "phantom" events if the primary dies before the standby received the commit.
+
+## Agreed decisions (P1–P10)
+
+| # | Decision |
+|---|---|
+| P1 | Predicate is **client-side, epoch-free, 32-bit**: `visible ⇔ int32(xid − uint32(xmax)) < 0 ∧ xid ∉ {uint32(x) : x ∈ xip}` over `pg_current_snapshot()::text` (`txid_current_snapshot()` on PG < 13). No `pg_xact_status`, no `pg_visible_in_snapshot`, no xid8/epoch reconstruction: `pg_snapshot_xmax` is `latestCompletedXid + 1`, so inside the gap `xid ≥ xmax` and any xmax-anchored epoch math is wrong. |
+| P2 | Guard connection lifetime is bound to the replication session: opened right after `IDENTIFY_SYSTEM`, to the same host as the replication DSN, autocommit, never reconnects on its own; any guard error is a stream error → existing restart path → redelivery from confirmed LSN. At open, **mandatory** checks: `pg_is_in_recovery() = false` and live timeline `== s.system.Timeline` via `pg_walfile_name(pg_current_wal_lsn())`. Per poll: `pg_is_in_recovery()` in the same statement as the snapshot (never `pg_walfile_name` per poll; it ERRORs in recovery). `system_identifier` is not compared (shared by the whole Patroni cluster). |
+| P3 | One knob `failMode`, default `closed`. closed = timeout or guard error ⇒ error ⇒ stream restart (with backoff and a distinct error class "visibility guard unreachable") ⇒ redelivery. open = dispatch after timeout with warning + counter. **No circuit breaker.** |
+| P4 | Timeout default 10 s. At open read `SHOW wal_sender_timeout`; if non-zero and gate timeout ≥ half of it, reject config with a clear error (while `process()` blocks, `messageCH` fills, sink blocks, keepalive replies stop). Poll 5 ms doubling to 250 ms cap with jitter. Non-positive durations rejected. |
+| P5 | Sync-rep corollary (documented, not code): with `synchronous_standby_names` active, "visible on primary" ⇒ "acknowledged by the sync standby at the configured `synchronous_commit` level", so a fail-closed gate also prevents phantom events on Patroni failover without PG17. Caveats: Patroni non-strict mode may turn sync off; cancel/terminate during `SyncRepWaitForLSN` makes the tx visible without ack (`syncrep.c:301-332`); per-session `synchronous_commit = local/off`; `remote_write` is receipt, not flush. |
+| P6 | `slot.failover: true` (PG17+) ⇒ `CREATE_REPLICATION_SLOT … (FAILOVER true)`; `ALTER_REPLICATION_SLOT … (FAILOVER true)` for an existing slot. Docs: needs `synchronized_standby_slots` on the primary (empty ⇒ no waiting), `sync_replication_slots` on standbys; an inactive listed slot stalls the logical walsender; Patroni ≥ 4.1.0 leaves failover slots alone and does not set the GUC. Complementary to the gate. |
+| P7 | Expose `CommitLSN` (= `Begin.FinalLSN`, start of the commit record) on every delivered message. Documented replica rule is **strict**: `pg_last_wal_replay_lsn() > CommitLSN` (or PG17 `pg_wal_replay_wait(CommitLSN)` then the same strict check). `>= TransactionEndLSN` is equivalent where the end LSN is available. |
+| P8 | `StreamAbort` sub-transaction bug is real and is fixed **first, in a separate PR**. |
+| P9 | Gate lives in `process()`, on the first message of each new xid. xid is stamped in `sink()` from `Begin.Xid` (non-streaming) and `StreamStart.Xid` (streaming); `flushWithLSN` / `flushTx` copy it when rebuilding `Message`. Heartbeat-table messages bypass the gate. Gate state reset on stream restart. Code comment: "everything in `messageCH` is committed on the server as long as `two_phase` is off" (`ReorderBufferCommit` is reached only from `DecodeCommit`; `DecodePrepare` would break it; this library never sends `two_phase`). |
+| P10 | Docs state the guarantee (a fresh snapshot on the same primary taken after dispatch sees the row) and its limits: replica reads, pooler routing to a replica, the consumer's own open REPEATABLE READ / SERIALIZABLE snapshot, later deletes, RLS/privileges. Consumer retry and self-contained outbox payloads remain recommended. Say plainly that replica/pooler routing is the more likely cause of the reported symptom in Patroni deployments. |
+
+## Build order
+
+### 0. Fix `StreamAbort` sub-transaction handling (separate PR, first)
+
+- Bug: `pq/replication/stream.go` `dispatchMessage` calls `streamBuf.discardTx(msg.Xid)` on every `StreamAbort`, but `format.StreamAbort` carries `Xid` **and** `SubXid`. A `ROLLBACK TO SAVEPOINT` or a plpgsql `EXCEPTION` block inside a transaction larger than `logical_decoding_work_mem` drops every buffered row; `STREAM COMMIT` then emits nothing. Default config (proto v2, streaming on) is affected.
+- Fix, mirroring `worker.c stream_abort_internal`: streamed DML messages already carry the (sub)xid (`format.Insert.XID` etc.). In `streamTxBuffer.append` record the slice index at which each new sub-xid first appears for the active top-level xid. On `StreamAbort` with `SubXid != Xid`, truncate `txns[Xid]` to that index and drop the recorded sub-xids at or after it. Only `SubXid == Xid` discards the whole transaction.
+- Tests: sub-abort in the middle of a chunk; nested sub-xids; interleaved transactions (TX-A chunk, TX-B chunk, TX-A sub-abort); top-level abort.
+
+### 1. Visibility gate (opt-in, core stream)
+
+Config (`config/config.go`, validated in `SetDefault`/validation path):
+
+```yaml
+visibilityGuard:
+  enabled: true
+  failMode: closed        # closed | open
+  timeout: 10s            # must be < wal_sender_timeout / 2 (checked at open; skipped when wal_sender_timeout = 0)
+  pollInterval: 5ms       # backoff doubles to 250ms cap, with jitter
+```
+
+Guard (`pq/replication/visibility.go`, rewrite; keep the existing parser test style):
+
+```sql
+-- at open (one statement); must return (false, s.system.Timeline)
+SELECT pg_is_in_recovery(),
+       ('x' || substr(pg_walfile_name(pg_current_wal_lsn()), 1, 8))::bit(32)::int;
+SHOW wal_sender_timeout;
+-- every poll (autocommit); PG < 13: txid_current_snapshot()
+SELECT pg_is_in_recovery(), pg_current_snapshot()::text;
+```
+
+- Parse `xmin:xmax:xip1,xip2,...` as uint64, compare with **low 32 bits** and PostgreSQL's modular rule (`int32(a-b) < 0`, valid within 2^31, same as the server). Cache the last parsed snapshot: an xid that precedes the cached `xmin` (modular compare) is visible without a query; anything else takes a fresh poll.
+- Probe `pg_current_snapshot()` at open; on `42883` switch to `txid_current_snapshot()` **and run it once** to confirm.
+- `pg_is_in_recovery() = true` on any poll, timeline mismatch at open, malformed snapshot: error (stream restart). Never treat errors as "visible".
+- The guard never reconnects. `Close()` order: cancel context first, then close guard, then replication connection; set the guard field to nil.
+
+Plumbing (`pq/replication/stream.go`):
+
+- Add `xid uint32` (and `commitLSN`, see step 2) to `Message`; stamp in `dispatchMessage` on `Begin` / `StreamStart`; `flushWithLSN` and `flushTx` must copy it.
+- In `process()`: keep `lastGatedXid`; when `msg.xid != lastGatedXid` and the message is not a heartbeat, call `guard.wait(ctx, xid)` before invoking the listener; on `closed` policy an error is returned from the stream (new error class) and the message is dropped un-acked; on `open` log warn, increment counter, dispatch.
+- Open the guard in `Open()` after `IdentifySystem` succeeded and slot capture is settled (avoid the `ErrorSlotInUse` retry churn), i.e. after `setup()`.
+- Metrics: `visibility_wait_duration` histogram, `visibility_timeout_total`, `visibility_fail_open_total`.
+
+Tests: predicate table (below xmin, in xip, between, wraparound at 2^32 boundary, xid ≥ xmax ⇒ not visible), snapshot cache, gate integration with a multi-message transaction (only the first message waits), streaming `flushTx` path, heartbeat bypass, `failMode` both ways, timeout-vs-`wal_sender_timeout` config rejection, `pg_is_in_recovery` flip mid-stream ⇒ error, close ordering.
+
+### 2. `CommitLSN` on every message
+
+`Begin.FinalLSN` is already parsed; carry it on `Message` and expose it on the listener context (streaming: `StreamCommit.TransactionEndLSN` is available in `flushTx`; still name the field `CommitLSN` and document the strict `>` rule).
+
+### 3. `slot.failover`
+
+`pq/slot/slot.go` currently builds `CREATE_REPLICATION_SLOT %s LOGICAL pgoutput` with no options. Add `failover` to `slot.Config`; append `(FAILOVER true)` on PG ≥ 17 (reject on older servers with a clear error); for an existing slot issue `ALTER_REPLICATION_SLOT %s (FAILOVER true)` when the option is on and `pg_replication_slots.failover` is false.
+
+### 4. Docs (README section)
+
+Mechanism in five lines, the config block, the guarantee and its limits (P10), the sync-rep corollary and caveats (P5), the PG17 failover-slot setup for Patroni (P6), the replica rule (P7).
+
+## Do not
+
+- Do not use `pg_xact_status`, `pg_visible_in_snapshot`, `txid_status`, or any xid8/epoch reconstruction.
+- Do not compare `system_identifier`.
+- Do not add a circuit breaker or a second failure knob.
+- Do not gate inside `sink()` (it owns keepalive replies) and do not gate at `COMMIT` (earlier rows are already emitted by the one-message look-ahead buffer).
+- Do not poll `pg_stat_replication` for "LSN on all replicas": it does not order against `ProcArrayEndTransaction`.
+- Do not call `txid_current()` / `pg_current_xact_id()` on the guard (they assign an xid).
+
+## Repo state to clean up before starting
+
+Untracked leftovers from an earlier exploration, all superseded by this document:
+
+- `pq/replication/visibility.go` — prototype with the epoch bug; references `config.VisibilityGuardConfig`, which does not exist, so the package does not compile as-is.
+- `pq/replication/visibility_test.go` — parser tests for the old predicate; the table-driven style is worth keeping, the expectations are not.
+- `REVIEW.md` — review of that prototype.
+
+Remove them (or rewrite in place) as the first step of the gate PR.
+
+## Source references (PostgreSQL master, 2026-09-03)
+
+`xact.c` RecordTransactionCommit: XactLogCommitRecord L1484, XLogFlush L1544, TransactionIdCommitTree L1550, SyncRepWaitForLSN L1599; CommitTransaction: ProcArrayEndTransaction L2430. `xlog.c` XLogFlush → WalSndWakeupProcessRequests L2943. `walsender.c` XLogSendLogical / GetFlushRecPtr; NeedToWaitForStandbys L1866 (checks `MyReplicationSlot->data.failover`). `slot.c` StandbySlotsHaveCaughtup. `decode.c` DecodeCommit → ReorderBufferCommit L755; DecodePrepare L359. `procarray.c` GetSnapshotData xmax = latestCompletedXid + 1 L2194; TransactionIdIsInProgress L1470. `syncrep.c` SyncRepWaitForLSN L149, fast exit L178-181, cancel/terminate escapes L301-332. `heapam_visibility.c` header comment (the race). `xid8funcs.c` pg_xact_status (in-progress before clog). `xlogfuncs.c` pg_walfile_name uses GetWALInsertionTimeLine, ERRORs in recovery. `system_functions.sql`: none of pg_control_*, pg_walfile_name, pg_current_wal_lsn, pg_current_snapshot, pg_is_in_recovery are REVOKEd. `worker.c` stream_abort_internal (sub-xid truncation). Patroni `docs/releases.rst`: 4.1.0 (2025-09-23) "Avoid interactions with slots created with the failover=true option"; 2.1.0 slot copy + pg_replication_slot_advance ("some events could be delivered more than once").

--- a/docs/visibility-gate-design.md
+++ b/docs/visibility-gate-design.md
@@ -1,6 +1,6 @@
 # Visibility gate — implementation handoff
 
-Status: **design agreed, not implemented.** Decided 2026-09-03 by a three-round consensus between Codex, Claude Opus 4.8 and Claude Fable 5.1, each verifying claims against PostgreSQL `master` sources. Full report (mechanism, verdict tables, decisions): https://claude.ai/code/artifact/555f3849-212d-4de4-ad33-0a10d01eb93d
+Status: **implemented** (PRs #166–#169 and the README sections "Visibility Guard", "Commit LSN and reading from a standby", "Failover slots"); kept as the design record. Decided 2026-09-03 by a three-round consensus between Codex, Claude Opus 4.8 and Claude Fable 5.1, each verifying claims against PostgreSQL `master` sources. Full report (mechanism, verdict tables, decisions): https://claude.ai/code/artifact/555f3849-212d-4de4-ad33-0a10d01eb93d
 
 ## Problem in two sentences
 

--- a/example/visibility-guard/README.md
+++ b/example/visibility-guard/README.md
@@ -1,0 +1,165 @@
+# Visibility Guard Lab
+
+A hands-on tour of three features on PostgreSQL 17: `visibilityGuard`, `ctx.CommitLSN` and `slot.failover`.
+The consumer in `main.go` plays a downstream service: for every insert event it opens a fresh snapshot on the
+primary and reports **VISIBLE** (the row is there) or **MISS** (the event arrived before the row is visible).
+
+## The window, in one paragraph
+
+When a transaction commits, PostgreSQL first writes the commit record to WAL and flushes it. At that moment the
+logical walsender already sends the change to go-pq-cdc. Only afterwards does the committing backend mark the
+transaction as finished so that new snapshots can see its rows. Normally that gap is microseconds. With
+synchronous replication (Patroni `synchronous_mode`) the backend waits for the standby's acknowledgement between
+those two steps, so the gap grows to a network round-trip, and a consumer that reads the primary right after the
+event can miss the row.
+
+This lab makes the gap infinite on purpose: `synchronous_standby_names = 'ghost'` makes every commit wait for a
+standby that does not exist. The WAL is flushed, the event is sent, the row stays invisible until you release it.
+
+## Setup
+
+```bash
+cd example/visibility-guard
+docker compose up -d --wait   # PostgreSQL 17 on port 5436 (5432-5435 are often taken)
+go run .                      # guard off
+```
+
+`./lab.sh` runs all six steps below unattended in about 30 seconds and prints what it saw; the manual walk-through
+is where the learning is.
+
+In a second terminal, open a psql session inside the container:
+
+```bash
+docker compose exec postgres psql -U cdc_user -d cdc_db
+```
+
+> Start the consumer **before** freezing commits. Creating the publication and the slot are commits too, and they
+> would hang.
+
+## 1. Guard off: see the MISS
+
+```sql
+INSERT INTO orders (note) VALUES ('normal');          -- consumer logs VISIBLE
+ALTER SYSTEM SET synchronous_standby_names = 'ghost';
+SELECT pg_reload_conf();                               -- from now on every commit waits forever
+INSERT INTO orders (note) VALUES ('frozen');          -- this statement hangs, that is the point
+```
+
+The consumer logs:
+
+```
+INFO VISIBLE id=1 note=normal commitLSN=0/192E498 walNow=0/192E4C8
+WARN MISS: event received but row not visible yet id=2 note=frozen commitLSN=0/192E558 walNow=0/192E588
+```
+
+In a third psql session `SELECT * FROM orders WHERE note = 'frozen'` returns nothing: the event exists, the row
+does not (yet).
+
+Release the commit:
+
+```sql
+ALTER SYSTEM RESET synchronous_standby_names;
+SELECT pg_reload_conf();                               -- the hanging INSERT returns, the row is visible
+```
+
+## 2. Guard on, `failMode: closed` (default)
+
+```bash
+go run . -guard -timeout 5s
+```
+
+```sql
+ALTER SYSTEM SET synchronous_standby_names = 'ghost';
+SELECT pg_reload_conf();
+INSERT INTO orders (note) VALUES ('frozen-closed');
+```
+
+Freeze and insert again. Nothing reaches the handler: the guard polls `pg_current_snapshot()` and the transaction
+is still in progress. After `timeout` the process logs `visibility guard failed, restarting stream` with the error
+class `visibility guard unreachable` and **exits** (the same crash-and-restart path as a lost replication
+connection; in production your orchestrator restarts it). The event was never acked, so it is redelivered on the
+next start. Release the commit, run the consumer again: the row arrives as VISIBLE.
+
+```
+ERROR visibility guard failed, restarting stream error="visibility guard unreachable: visibility guard timeout: xid 744 not visible after 5s"
+(process exits; release; start again)
+INFO VISIBLE id=3 note=frozen-closed commitLSN=0/192E620 walNow=0/192E688
+```
+
+Closed means "never hand out an event I cannot certify". The price is a restart loop while the primary is stuck,
+which is what you want to be alerted on.
+
+## 3. Guard on, `failMode: open`
+
+```bash
+go run . -guard -fail-mode open -timeout 3s
+```
+
+```sql
+ALTER SYSTEM SET synchronous_standby_names = 'ghost';
+SELECT pg_reload_conf();
+INSERT INTO orders (note) VALUES ('frozen-closed-v2');
+```
+
+Freeze and insert. After `timeout` the consumer logs `visibility guard timeout, dispatching anyway (failMode: open)`
+followed by the MISS, and keeps running. Check the counters:
+
+```bash
+curl -s localhost:8081/metrics | grep visibility
+```
+
+```
+WARN visibility guard timeout, dispatching anyway (failMode: open) xid=745
+WARN MISS: event received but row not visible yet id=4 note=frozen-open ...
+go_pq_cdc_visibility_timeout_total{...} 1
+go_pq_cdc_visibility_fail_open_total{...} 1
+```
+
+Open means "prefer latency over certainty and tell me about it". Release the commit when done.
+
+## 4. Caveat: sessions that skip the wait
+
+```sql
+SET synchronous_commit = off;
+INSERT INTO orders (note) VALUES ('async');           -- returns immediately even while frozen
+```
+
+The row is visible at once and the guard lets the event through: the session opted out of the standby wait, so
+"visible on the primary" no longer implies "acknowledged by the standby". This is the first caveat of the
+synchronous-replication corollary in the README; `pg_cancel_backend(<pid of a hanging INSERT>)` demonstrates the
+second one (the transaction commits locally and becomes visible without the acknowledgement).
+
+## 5. `ctx.CommitLSN`
+
+Every VISIBLE/MISS line prints `commitLSN` (the transaction's commit record) next to `walNow`
+(`pg_current_wal_lsn()` at read time). On a standby the read rule is strict:
+
+```sql
+SELECT pg_last_wal_replay_lsn() > '<commitLSN>'::pg_lsn;
+```
+
+`pg_last_wal_replay_lsn()` is the end of the last replayed record, so it equals `commitLSN` just before the
+commit record is applied; `>=` would pass too early.
+
+## 6. Failover slot
+
+Stop the consumer (the slot must be inactive for `ALTER_REPLICATION_SLOT`), then:
+
+```bash
+go run . -failover
+```
+
+```sql
+SELECT slot_name, failover FROM pg_replication_slots;  -- cdc_slot | t
+```
+
+The existing slot was altered; a fresh slot would be created with `FAILOVER true`. Switch the image in
+`docker-compose.yml` to `postgres:16-alpine` and the same flag fails at startup with
+`slot.failover requires PostgreSQL 17 or newer`. A failover slot only pays off with a standby running
+`sync_replication_slots` and `synchronized_standby_slots` set on the primary; see the main README.
+
+## Cleanup
+
+```bash
+docker compose down -v
+```

--- a/example/visibility-guard/docker-compose.yml
+++ b/example/visibility-guard/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: cdc_db
+      POSTGRES_USER: cdc_user
+      POSTGRES_PASSWORD: cdc_pass
+    ports:
+      - "5436:5432"
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+      - -c
+      - max_replication_slots=20
+      - -c
+      - max_wal_senders=25
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U cdc_user -d cdc_db" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/example/visibility-guard/init.sql
+++ b/example/visibility-guard/init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE orders (
+   id serial PRIMARY KEY,
+   note text NOT NULL,
+   created_at timestamptz DEFAULT now()
+);

--- a/example/visibility-guard/lab.sh
+++ b/example/visibility-guard/lab.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Runs the six README steps unattended against the docker-compose PostgreSQL 17.
+# Needs: docker compose, go, curl. Prints one or two lines per step.
+set -eu
+cd "$(dirname "$0")"
+BIN=$(mktemp -d)/vg
+LOG=$(mktemp -d)
+docker compose up -d --wait >/dev/null 2>&1
+go build -o "$BIN" .
+psql()    { docker compose exec -T postgres psql -U cdc_user -d cdc_db -Atc "$1"; }
+waitlog() { i=0; until grep -q "$2" "$1"; do i=$((i+1)); [ $i -gt 80 ] && { echo "timeout waiting for '$2'"; return 1; }; sleep 0.5; done; }
+freeze()  { psql "ALTER SYSTEM SET synchronous_standby_names = 'ghost'" >/dev/null; psql "SELECT pg_reload_conf()" >/dev/null; }
+release() { psql "ALTER SYSTEM RESET synchronous_standby_names" >/dev/null; psql "SELECT pg_reload_conf()" >/dev/null; }
+start()   { "$BIN" "$@" > "$LOG/cur.log" 2>&1 & PID=$!; waitlog "$LOG/cur.log" "slot captured"; }
+stop()    { kill $PID 2>/dev/null; wait $PID 2>/dev/null || true; }
+insert()  { psql "INSERT INTO orders (note) VALUES ('$1')" >/dev/null & INS=$!; }
+
+echo "## 1. guard off"
+start
+psql "INSERT INTO orders (note) VALUES ('normal')" >/dev/null; waitlog "$LOG/cur.log" VISIBLE; grep VISIBLE "$LOG/cur.log" | tail -1
+freeze; insert frozen; waitlog "$LOG/cur.log" MISS; grep MISS "$LOG/cur.log" | tail -1
+echo "rows visible to a fresh session while frozen: $(psql "SELECT count(*) FROM orders WHERE note = 'frozen'")"
+release; wait $INS; stop
+
+echo "## 2. guard on, failMode closed"
+start -guard -timeout 5s
+freeze; insert frozen-closed; waitlog "$LOG/cur.log" "visibility guard failed"; grep "visibility guard failed" "$LOG/cur.log" | tail -1
+wait $PID 2>/dev/null || echo "consumer exited, event not acked"
+release; wait $INS
+start -guard -timeout 5s; waitlog "$LOG/cur.log" frozen-closed; grep frozen-closed "$LOG/cur.log" | tail -1; stop
+
+echo "## 3. guard on, failMode open"
+start -guard -fail-mode open -timeout 3s
+freeze; insert frozen-open; waitlog "$LOG/cur.log" MISS; grep -E "dispatching anyway|MISS" "$LOG/cur.log" | tail -2
+curl -s localhost:8081/metrics | grep -E "^go_pq_cdc_visibility_(timeout|fail_open)_total"
+release; wait $INS; stop
+
+echo "## 4. caveat: synchronous_commit = off"
+start -guard -timeout 5s
+freeze; psql "SET synchronous_commit = off; INSERT INTO orders (note) VALUES ('async')" >/dev/null
+waitlog "$LOG/cur.log" async; grep async "$LOG/cur.log" | tail -1
+release; stop
+
+echo "## 5. CommitLSN: compare commitLSN with walNow in the lines above"
+
+echo "## 6. failover slot"
+echo "before: $(psql "SELECT failover FROM pg_replication_slots WHERE slot_name = 'cdc_slot'")"
+start -failover; stop
+echo "after:  $(psql "SELECT failover FROM pg_replication_slots WHERE slot_name = 'cdc_slot'")"
+
+docker compose down -v >/dev/null 2>&1
+echo "done"

--- a/example/visibility-guard/main.go
+++ b/example/visibility-guard/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"os"
+	"time"
+
+	cdc "github.com/Trendyol/go-pq-cdc"
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/Trendyol/go-pq-cdc/pq/publication"
+	"github.com/Trendyol/go-pq-cdc/pq/replication"
+	"github.com/Trendyol/go-pq-cdc/pq/slot"
+	"github.com/jackc/pgx/v5"
+)
+
+// The handler plays a downstream service: for every insert event it opens a
+// fresh snapshot on the primary and checks whether the row is there yet.
+// VISIBLE is what you expect; MISS is the read-after-write window. See README.md.
+func main() {
+	guard := flag.Bool("guard", false, "enable visibilityGuard")
+	failMode := flag.String("fail-mode", "closed", "visibilityGuard.failMode: closed | open")
+	timeout := flag.Duration("timeout", 10*time.Second, "visibilityGuard.timeout (must be < wal_sender_timeout/2)")
+	failover := flag.Bool("failover", false, "slot.failover (PostgreSQL 17+)")
+	flag.Parse()
+
+	ctx := context.Background()
+	cfg := config.Config{
+		Host:     "127.0.0.1",
+		Port:     5436,
+		Username: "cdc_user",
+		Password: "cdc_pass",
+		Database: "cdc_db",
+		Publication: publication.Config{
+			CreateIfNotExists: true,
+			Name:              "cdc_publication",
+			Operations:        publication.Operations{publication.OperationInsert},
+			Tables: publication.Tables{
+				{Name: "orders", Schema: "public", ReplicaIdentity: publication.ReplicaIdentityDefault},
+			},
+		},
+		Slot: slot.Config{
+			CreateIfNotExists:           true,
+			Name:                        "cdc_slot",
+			SlotActivityCheckerInterval: 3000,
+			Failover:                    *failover,
+		},
+		VisibilityGuard: config.VisibilityGuardConfig{
+			Enabled:  *guard,
+			FailMode: config.VisibilityFailMode(*failMode),
+			Timeout:  *timeout,
+		},
+		Metric: config.MetricConfig{Port: 8081},
+		Logger: config.LoggerConfig{LogLevel: slog.LevelInfo},
+	}
+
+	// Separate autocommit connection: each query takes a fresh snapshot,
+	// exactly what a service reading the primary right after the event would see.
+	reader, err := pgx.Connect(ctx, cfg.DSNWithoutSSL())
+	if err != nil {
+		slog.Error("reader connect", "error", err)
+		os.Exit(1)
+	}
+	defer reader.Close(ctx)
+
+	handler := func(lCtx *replication.ListenerContext) {
+		if ins, ok := lCtx.Message.(*format.Insert); ok {
+			id := ins.Decoded["id"]
+			var visible bool
+			var walNow string
+			err := reader.QueryRow(lCtx.Context,
+				"SELECT EXISTS (SELECT 1 FROM orders WHERE id = $1), pg_current_wal_lsn()::text", id,
+			).Scan(&visible, &walNow)
+			switch {
+			case err != nil:
+				slog.Error("read after event", "id", id, "error", err)
+			case visible:
+				slog.Info("VISIBLE", "id", id, "note", ins.Decoded["note"], "commitLSN", lCtx.CommitLSN.String(), "walNow", walNow)
+			default:
+				slog.Warn("MISS: event received but row not visible yet", "id", id, "note", ins.Decoded["note"], "commitLSN", lCtx.CommitLSN.String(), "walNow", walNow)
+			}
+		}
+		if err := lCtx.Ack(); err != nil {
+			slog.Error("ack", "error", err)
+		}
+	}
+
+	connector, err := cdc.NewConnector(ctx, cfg, handler)
+	if err != nil {
+		slog.Error("new connector", "error", err)
+		os.Exit(1)
+	}
+	defer connector.Close()
+	connector.Start(ctx)
+}

--- a/integration_test/slot_failover_test.go
+++ b/integration_test/slot_failover_test.go
@@ -1,0 +1,84 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"testing"
+
+	"github.com/Trendyol/go-pq-cdc/logger"
+	"github.com/Trendyol/go-pq-cdc/pq"
+	"github.com/Trendyol/go-pq-cdc/pq/slot"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSlotFailover covers slot.failover against a real server: on
+// PostgreSQL 17+ a fresh slot is created with FAILOVER true and an existing
+// slot created without it is altered; older servers reject the option with a
+// clear error instead of a CREATE_REPLICATION_SLOT syntax error.
+func TestSlotFailover(t *testing.T) {
+	const (
+		existingSlot = "slot_test_failover_existing"
+		freshSlot    = "slot_test_failover_fresh"
+	)
+	ctx := context.Background()
+	logger.InitLogger(logger.NewSlog(slog.LevelError)) // slot is used without a connector here
+
+	postgresConn, err := newPostgresConn()
+	require.NoError(t, err)
+	defer func() { _ = postgresConn.Close(ctx) }()
+
+	newSlot := func(name string, failover bool) *slot.Slot {
+		cfg := Config.Slot
+		cfg.Name = name
+		cfg.CreateIfNotExists = true
+		cfg.SlotActivityCheckerInterval = 1000
+		cfg.Failover = failover
+		return slot.NewSlot(Config.ReplicationDSN(), Config.DSN(), cfg, nil, nil)
+	}
+	dropSlot := func(name string) {
+		_ = pgExec(ctx, postgresConn, fmt.Sprintf("SELECT pg_drop_replication_slot('%s') WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '%s')", name, name))
+	}
+	failoverFlag := func(name string) string {
+		return pgScalar(t, ctx, postgresConn, fmt.Sprintf("SELECT failover FROM pg_replication_slots WHERE slot_name = '%s'", name))
+	}
+
+	version, err := strconv.Atoi(pgScalar(t, ctx, postgresConn, "SHOW server_version_num"))
+	require.NoError(t, err)
+
+	if version < 170000 {
+		_, err := newSlot(freshSlot, true).Create(ctx)
+		require.ErrorContains(t, err, "slot.failover requires PostgreSQL 17")
+		return
+	}
+
+	// Existing slot without failover → enabled by ALTER_REPLICATION_SLOT on the next Create.
+	dropSlot(existingSlot)
+	defer dropSlot(existingSlot)
+	_, err = newSlot(existingSlot, false).Create(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "f", failoverFlag(existingSlot))
+	_, err = newSlot(existingSlot, true).Create(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "t", failoverFlag(existingSlot))
+	// Idempotent: already enabled, nothing to alter.
+	_, err = newSlot(existingSlot, true).Create(ctx)
+	require.NoError(t, err)
+
+	// Fresh slot created with FAILOVER true.
+	dropSlot(freshSlot)
+	defer dropSlot(freshSlot)
+	_, err = newSlot(freshSlot, true).Create(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "t", failoverFlag(freshSlot))
+}
+
+func pgScalar(t *testing.T, ctx context.Context, conn pq.Connection, sql string) string {
+	t.Helper()
+	results, err := conn.Exec(ctx, sql).ReadAll()
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	require.NotEmpty(t, results[0].Rows)
+	return string(results[0].Rows[0][0])
+}

--- a/integration_test/visibility_guard_test.go
+++ b/integration_test/visibility_guard_test.go
@@ -1,0 +1,148 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	cdc "github.com/Trendyol/go-pq-cdc"
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/Trendyol/go-pq-cdc/pq/replication"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestVisibilityGuardRowIsVisibleWhenDispatched enables the visibility guard
+// and, from inside the handler, reads the primary with a fresh snapshot: every
+// delivered insert must already be visible. Covers the guard open checks
+// (primary, timeline, wal_sender_timeout, snapshot function) and both the
+// regular and the streamed (proto v2, low logical_decoding_work_mem) paths
+// against a real server.
+func TestVisibilityGuardRowIsVisibleWhenDispatched(t *testing.T) {
+	const (
+		smallRows = 20
+		largeRows = 500
+		slotName  = "slot_test_visibility_guard"
+		smallBase = 95000
+		largeBase = 96000
+	)
+
+	ctx := context.Background()
+	lowerLogicalDecodingWorkMem(ctx, t)
+
+	cdcCfg := Config
+	cdcCfg.Slot.Name = slotName
+	cdcCfg.Slot.ProtoVersion = 2
+	cdcCfg.VisibilityGuard = config.VisibilityGuardConfig{Enabled: true, FailMode: config.VisibilityFailClosed}
+
+	postgresConn, err := newPostgresConn()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	if !assert.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg)) {
+		t.FailNow()
+	}
+
+	cfg := config.Config{Host: Config.Host, Port: Config.Port, Username: "postgres", Password: "postgres", Database: Config.Database}
+	pool, err := pgxpool.New(ctx, cfg.DSNWithoutSSL())
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	type seen struct {
+		id      int32
+		visible bool
+	}
+	seenCh := make(chan seen, smallRows+largeRows)
+	handler := func(lCtx *replication.ListenerContext) {
+		if ins, ok := lCtx.Message.(*format.Insert); ok {
+			id := ins.Decoded["id"].(int32)
+			var n int
+			err := pool.QueryRow(ctx, "SELECT count(*) FROM books WHERE id = $1", id).Scan(&n)
+			seenCh <- seen{id: id, visible: err == nil && n == 1}
+		}
+		_ = lCtx.Ack()
+	}
+
+	connector, err := cdc.NewConnector(ctx, cdcCfg, handler)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	t.Cleanup(func() {
+		connector.Close()
+		_ = RestoreDB(ctx)
+		pool.Close()
+		_ = postgresConn.Close(ctx)
+	})
+
+	go connector.Start(ctx)
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	assert.NoError(t, connector.WaitUntilReady(waitCtx))
+	cancel()
+
+	// Many small transactions (regular path) …
+	for i := 0; i < smallRows; i++ {
+		_, err = pool.Exec(ctx, "INSERT INTO books (id, name) VALUES ($1, $2)", smallBase+i, fmt.Sprintf("small-%d", i))
+		assert.NoError(t, err)
+	}
+	// … and one large streamed transaction.
+	tx, err := pool.Begin(ctx)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	for i := 0; i < largeRows; i++ {
+		_, err = tx.Exec(ctx, "INSERT INTO books (id, name) VALUES ($1, $2)", largeBase+i, fmt.Sprintf("large-%d", i))
+		assert.NoError(t, err)
+	}
+	assert.NoError(t, tx.Commit(ctx))
+
+	got := make(map[int32]struct{}, smallRows+largeRows)
+	deadline := time.After(20 * time.Second)
+	for len(got) < smallRows+largeRows {
+		select {
+		case <-deadline:
+			t.Fatalf("timeout: expected %d inserts, got %d", smallRows+largeRows, len(got))
+		case s := <-seenCh:
+			if !s.visible {
+				t.Fatalf("row %d was dispatched before it was visible on the primary", s.id)
+			}
+			got[s.id] = struct{}{}
+		}
+	}
+}
+
+// TestVisibilityGuardRejectsTimeoutAboveHalfWalSenderTimeout: the guard refuses
+// to start when the gate could outlast the walsender's keepalive budget.
+func TestVisibilityGuardRejectsTimeoutAboveHalfWalSenderTimeout(t *testing.T) {
+	ctx := context.Background()
+
+	cdcCfg := Config
+	cdcCfg.Slot.Name = "slot_test_visibility_guard_reject"
+	cdcCfg.VisibilityGuard = config.VisibilityGuardConfig{Enabled: true, Timeout: time.Hour}
+
+	postgresConn, err := newPostgresConn()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	if !assert.NoError(t, SetupTestDB(ctx, postgresConn, cdcCfg)) {
+		t.FailNow()
+	}
+
+	connector, err := cdc.NewConnector(ctx, cdcCfg, func(lCtx *replication.ListenerContext) { _ = lCtx.Ack() })
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	t.Cleanup(func() {
+		connector.Close()
+		_ = RestoreDB(ctx)
+		_ = postgresConn.Close(ctx)
+	})
+
+	go connector.Start(ctx)
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	assert.Error(t, connector.WaitUntilReady(waitCtx), "stream must not become ready with a rejected guard config")
+}

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -2,6 +2,7 @@ package metric
 
 import (
 	"os"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -35,6 +36,11 @@ type Metric interface {
 	SetSnapshotCompletedChunks(completed int)
 	SetSnapshotActiveWorkers(workers int)
 
+	// Visibility guard metrics
+	ObserveVisibilityWait(d time.Duration)
+	VisibilityTimeoutIncrement()
+	VisibilityFailOpenIncrement()
+
 	PrometheusCollectors() []prometheus.Collector
 }
 
@@ -64,6 +70,11 @@ type metric struct {
 	snapshotTotalChunks     prometheus.Gauge
 	snapshotCompletedChunks prometheus.Gauge
 	snapshotActiveWorkers   prometheus.Gauge
+
+	// Visibility guard metrics
+	visibilityWaitDuration  prometheus.Histogram
+	visibilityTimeoutTotal  prometheus.Counter
+	visibilityFailOpenTotal prometheus.Counter
 }
 
 //nolint:funlen
@@ -270,6 +281,37 @@ func NewMetric(slotName string) Metric {
 				"host":      hostname,
 			},
 		}),
+		visibilityWaitDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: cdcNamespace,
+			Subsystem: "visibility",
+			Name:      "wait_duration_seconds",
+			Help:      "time the visibility guard held a transaction until it became visible on the primary",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
+			ConstLabels: prometheus.Labels{
+				"slot_name": slotName,
+				"host":      hostname,
+			},
+		}),
+		visibilityTimeoutTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: cdcNamespace,
+			Subsystem: "visibility",
+			Name:      "timeout_total",
+			Help:      "number of visibility guard waits that reached visibilityGuard.timeout",
+			ConstLabels: prometheus.Labels{
+				"slot_name": slotName,
+				"host":      hostname,
+			},
+		}),
+		visibilityFailOpenTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: cdcNamespace,
+			Subsystem: "visibility",
+			Name:      "fail_open_total",
+			Help:      "number of messages dispatched after a visibility guard timeout (failMode: open)",
+			ConstLabels: prometheus.Labels{
+				"slot_name": slotName,
+				"host":      hostname,
+			},
+		}),
 	}
 }
 
@@ -295,6 +337,9 @@ func (m *metric) PrometheusCollectors() []prometheus.Collector {
 		m.snapshotTotalChunks,
 		m.snapshotCompletedChunks,
 		m.snapshotActiveWorkers,
+		m.visibilityWaitDuration,
+		m.visibilityTimeoutTotal,
+		m.visibilityFailOpenTotal,
 	}
 }
 
@@ -379,4 +424,16 @@ func (m *metric) SetSnapshotCompletedChunks(completed int) {
 
 func (m *metric) SetSnapshotActiveWorkers(workers int) {
 	m.snapshotActiveWorkers.Set(float64(workers))
+}
+
+func (m *metric) ObserveVisibilityWait(d time.Duration) {
+	m.visibilityWaitDuration.Observe(d.Seconds())
+}
+
+func (m *metric) VisibilityTimeoutIncrement() {
+	m.visibilityTimeoutTotal.Inc()
+}
+
+func (m *metric) VisibilityFailOpenIncrement() {
+	m.visibilityFailOpenTotal.Inc()
 }

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -40,6 +40,15 @@ type ListenerContext struct {
 	Context context.Context
 	Message any
 	Ack     func() error
+	// CommitLSN is the start of the commit record of the transaction that
+	// produced Message (pgoutput Begin.FinalLSN, StreamCommit.CommitLSN for
+	// streamed transactions). Zero for snapshot events.
+	//
+	// A standby has applied that transaction only once
+	// pg_last_wal_replay_lsn() > CommitLSN. The comparison is strict:
+	// pg_last_wal_replay_lsn() reports the end of the last replayed record, so
+	// it equals CommitLSN right before the commit record itself is applied.
+	CommitLSN pq.LSN
 }
 
 type ListenerFunc func(ctx *ListenerContext)
@@ -50,6 +59,9 @@ type Message struct {
 	// xid is the top-level transaction the message belongs to (Begin.Xid or
 	// StreamStart.Xid); the visibility guard gates on it.
 	xid uint32
+	// commitLSN is the start of the transaction's commit record, exposed as
+	// ListenerContext.CommitLSN.
+	commitLSN pq.LSN
 }
 
 type Streamer interface {
@@ -191,10 +203,11 @@ func (s *stream) setup(ctx context.Context) error {
 // All preceding messages are emitted immediately with their original position.
 // This keeps memory usage O(1) regardless of transaction size.
 type messageBuffer struct {
-	pending *Message
-	outCh   chan<- *Message
-	ctx     context.Context
-	xid     uint32 // current transaction, from Begin
+	pending   *Message
+	outCh     chan<- *Message
+	ctx       context.Context
+	xid       uint32 // current transaction, from Begin
+	commitLSN pq.LSN // current transaction's commit record, from Begin.FinalLSN
 }
 
 func (b *messageBuffer) send(msg *Message) bool {
@@ -224,9 +237,10 @@ func (b *messageBuffer) flush() {
 func (b *messageBuffer) flushWithLSN(lsn pq.LSN) {
 	if b.pending != nil {
 		if !b.send(&Message{
-			message:  b.pending.message,
-			walStart: int64(lsn),
-			xid:      b.pending.xid,
+			message:   b.pending.message,
+			walStart:  int64(lsn),
+			xid:       b.pending.xid,
+			commitLSN: b.pending.commitLSN,
 		}) {
 			return
 		}
@@ -314,18 +328,21 @@ func (s *streamTxBuffer) stopTx() {
 }
 
 // flushTx emits every accumulated message for the given XID through outCh.
-// The last message's WAL position is rewritten to the transaction-end LSN.
-func (s *streamTxBuffer) flushTx(xid uint32, outCh chan<- *Message, endLSN pq.LSN) {
+// Every message is stamped with the commit LSN (known only at STREAM COMMIT);
+// the last message's WAL position is rewritten to the transaction-end LSN.
+func (s *streamTxBuffer) flushTx(xid uint32, outCh chan<- *Message, commitLSN, endLSN pq.LSN) {
 	s.streaming = false
 	msgs := s.txns[xid]
 	n := len(msgs)
 	for i, msg := range msgs {
+		msg.commitLSN = commitLSN
 		out := msg
 		if i == n-1 {
 			out = &Message{
-				message:  msg.message,
-				walStart: int64(endLSN),
-				xid:      msg.xid,
+				message:   msg.message,
+				walStart:  int64(endLSN),
+				xid:       msg.xid,
+				commitLSN: commitLSN,
 			}
 		}
 		ctx := s.ctx
@@ -550,6 +567,7 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 	case *format.Begin:
 		buf.discard()
 		buf.xid = msg.Xid
+		buf.commitLSN = msg.FinalLSN
 
 	case *format.Commit:
 		buf.flushWithLSN(msg.TransactionEndLSN)
@@ -565,7 +583,7 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 
 	case *format.StreamCommit:
 		// Final commit of a streamed transaction – emit all messages for this XID.
-		streamBuf.flushTx(msg.Xid, buf.outCh, msg.TransactionEndLSN)
+		streamBuf.flushTx(msg.Xid, buf.outCh, msg.CommitLSN, msg.TransactionEndLSN)
 
 	case *format.StreamAbort:
 		// Whole transaction (SubXid == Xid) or a single sub-transaction
@@ -583,6 +601,7 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 			streamBuf.append(m, messageXid(decodedMsg))
 		} else {
 			m.xid = buf.xid
+			m.commitLSN = buf.commitLSN
 			buf.buffer(m)
 		}
 	}
@@ -685,9 +704,10 @@ func (s *stream) processLoop(ctx context.Context) error {
 			}
 
 			lCtx := &ListenerContext{
-				Context: ctx,
-				Message: msg.message,
-				Ack:     ackFunc,
+				Context:   ctx,
+				Message:   msg.message,
+				Ack:       ackFunc,
+				CommitLSN: msg.commitLSN,
 			}
 
 			switch lCtx.Message.(type) {

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -47,6 +47,9 @@ type ListenerFunc func(ctx *ListenerContext)
 type Message struct {
 	message  any
 	walStart int64
+	// xid is the top-level transaction the message belongs to (Begin.Xid or
+	// StreamStart.Xid); the visibility guard gates on it.
+	xid uint32
 }
 
 type Streamer interface {
@@ -61,6 +64,7 @@ type Streamer interface {
 type stream struct {
 	metric              metric.Metric
 	conn                pq.Connection
+	guard               *visibilityGuard
 	cancel              context.CancelFunc
 	system              *pq.IdentifySystemResult
 	relation            map[uint32]*format.Relation
@@ -128,6 +132,16 @@ func (s *stream) Open(ctx context.Context) error {
 		return errors.Wrap(err, "replication setup")
 	}
 
+	// Opened after setup so the ErrorSlotInUse retry loop never churns guard
+	// connections; bound to this replication session (same host, same timeline).
+	if s.config.VisibilityGuard.Enabled {
+		guard, err := openVisibilityGuard(ctx, s.config.DSN(), s.config.VisibilityGuard, s.system.Timeline, s.metric)
+		if err != nil {
+			return errors.Wrap(err, "visibility guard")
+		}
+		s.guard = guard
+	}
+
 	s.sinkStarted.Store(true)
 	s.processStarted.Store(true)
 	runCtx, cancel := context.WithCancel(ctx)
@@ -180,6 +194,7 @@ type messageBuffer struct {
 	pending *Message
 	outCh   chan<- *Message
 	ctx     context.Context
+	xid     uint32 // current transaction, from Begin
 }
 
 func (b *messageBuffer) send(msg *Message) bool {
@@ -211,6 +226,7 @@ func (b *messageBuffer) flushWithLSN(lsn pq.LSN) {
 		if !b.send(&Message{
 			message:  b.pending.message,
 			walStart: int64(lsn),
+			xid:      b.pending.xid,
 		}) {
 			return
 		}
@@ -309,6 +325,7 @@ func (s *streamTxBuffer) flushTx(xid uint32, outCh chan<- *Message, endLSN pq.LS
 			out = &Message{
 				message:  msg.message,
 				walStart: int64(endLSN),
+				xid:      msg.xid,
 			}
 		}
 		ctx := s.ctx
@@ -532,6 +549,7 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 	switch msg := decodedMsg.(type) {
 	case *format.Begin:
 		buf.discard()
+		buf.xid = msg.Xid
 
 	case *format.Commit:
 		buf.flushWithLSN(msg.TransactionEndLSN)
@@ -561,8 +579,10 @@ func (s *stream) dispatchMessage(decodedMsg any, xld XLogData, buf *messageBuffe
 			walStart: int64(xld.WALStart),
 		}
 		if streamBuf.streaming {
+			m.xid = streamBuf.activeXid
 			streamBuf.append(m, messageXid(decodedMsg))
 		} else {
+			m.xid = buf.xid
 			buf.buffer(m)
 		}
 	}
@@ -588,19 +608,44 @@ func messageXid(msg any) uint32 {
 
 func (s *stream) process(ctx context.Context) {
 	logger.Info("postgres message process started")
-	defer func() {
-		s.processEnd <- struct{}{}
-	}()
+	err := s.processLoop(ctx)
+	s.processEnd <- struct{}{}
+	if err == nil || s.closed.Load() {
+		return
+	}
+
+	// Same restart path as the sink's corrupted connection: shut the stream
+	// down (flushing the confirmed LSN) and crash so the process restarts with
+	// fresh connections. The gated message was never acked, so it is redelivered.
+	logger.Error("visibility guard failed, restarting stream", "error", err)
+	closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), streamShutdownTimeout)
+	defer cancel()
+	if cErr := s.Close(closeCtx); cErr != nil {
+		logger.Error("replication stream shutdown failed", "error", cErr)
+	}
+	panic(err)
+}
+
+// processLoop delivers messages to the listener until the context is done or
+// the message channel is closed. It returns an error only when the visibility
+// guard can no longer certify visibility (failMode: closed, or a guard error).
+//
+// Everything in messageCH is committed on the server as long as two_phase is
+// off: ReorderBufferCommit is reached only from DecodeCommit, and this library
+// never requests two_phase. The gate therefore only waits for the commit to
+// become visible, never for it to happen.
+func (s *stream) processLoop(ctx context.Context) error {
+	var lastGatedXid uint32
 
 	for {
 		select {
 		case <-ctx.Done():
 			logger.Info("postgres message process stopped")
-			return
+			return nil
 		case msg, ok := <-s.messageCH:
 			if !ok {
 				logger.Info("postgres message process stopped")
-				return
+				return nil
 			}
 			if msg == nil {
 				continue
@@ -625,6 +670,20 @@ func (s *stream) process(ctx context.Context) {
 				continue
 			}
 
+			// Gate once per transaction, on its first message.
+			if s.guard != nil && msg.xid != lastGatedXid {
+				if err := s.gate(ctx, msg.xid); err != nil {
+					if ctx.Err() != nil {
+						// Shutting down mid-wait: never dispatch an uncertified message.
+						// It stays un-acked and is redelivered after restart.
+						logger.Info("postgres message process stopped")
+						return nil
+					}
+					return err
+				}
+				lastGatedXid = msg.xid
+			}
+
 			lCtx := &ListenerContext{
 				Context: ctx,
 				Message: msg.message,
@@ -644,6 +703,23 @@ func (s *stream) process(ctx context.Context) {
 			s.listenerFunc(lCtx)
 			s.metric.SetProcessLatency(time.Since(start).Nanoseconds())
 		}
+	}
+}
+
+// gate waits until xid is visible on the primary. A timeout is fatal under
+// failMode closed and a logged, counted pass-through under failMode open; any
+// other guard error is fatal in both modes.
+func (s *stream) gate(ctx context.Context, xid uint32) error {
+	err := s.guard.wait(ctx, xid)
+	switch {
+	case err == nil:
+		return nil
+	case goerrors.Is(err, ErrVisibilityTimeout) && s.config.VisibilityGuard.FailMode == config.VisibilityFailOpen:
+		logger.Warn("visibility guard timeout, dispatching anyway (failMode: open)", "xid", xid, "error", err)
+		s.metric.VisibilityFailOpenIncrement()
+		return nil
+	default:
+		return fmt.Errorf("%w: %w", ErrVisibilityGuard, err)
 	}
 }
 
@@ -678,10 +754,16 @@ func (s *stream) Close(ctx context.Context) error {
 	}
 	var errs []error
 
-	// Close the PostgreSQL socket first. A listener callback is synchronous and
-	// may be blocked outside this package; waiting for it before closing the
-	// socket can leave the walsender connection open for the whole shutdown
-	// timeout.
+	// Cancel first so a process goroutine blocked in the visibility guard (or a
+	// context-aware listener) returns instead of waiting out its timeout.
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	// Close the PostgreSQL socket before waiting on the goroutines. A listener
+	// callback is synchronous and may be blocked outside this package; waiting
+	// for it before closing the socket can leave the walsender connection open
+	// for the whole shutdown timeout.
 	s.connMu.Lock()
 	if !s.conn.IsClosed() {
 		s.flushFinalStandbyStatusUpdateLocked(ctx)
@@ -691,9 +773,6 @@ func (s *stream) Close(ctx context.Context) error {
 		logger.Info("postgres connection closed")
 	}
 	s.connMu.Unlock()
-	if s.cancel != nil {
-		s.cancel()
-	}
 
 	if s.sinkStarted.Load() {
 		select {
@@ -713,6 +792,15 @@ func (s *stream) Close(ctx context.Context) error {
 			logger.Warn("timed out waiting for postgres message process", "error", ctx.Err())
 			errs = append(errs, errors.Wrap(ctx.Err(), "wait for postgres message process"))
 		}
+	}
+
+	// Only the process goroutine uses the guard connection; close it after that
+	// goroutine has stopped so the close never races an in-flight poll.
+	if s.guard != nil {
+		if err := s.guard.close(ctx); err != nil {
+			errs = append(errs, errors.Wrap(err, "close visibility guard"))
+		}
+		logger.Info("visibility guard connection closed")
 	}
 
 	return goerrors.Join(errs...)

--- a/pq/replication/stream.go
+++ b/pq/replication/stream.go
@@ -152,6 +152,11 @@ func (s *stream) Open(ctx context.Context) error {
 			return errors.Wrap(err, "visibility guard")
 		}
 		s.guard = guard
+		logger.Info("visibility guard enabled",
+			"failMode", s.config.VisibilityGuard.FailMode,
+			"timeout", s.config.VisibilityGuard.Timeout,
+			"pollInterval", s.config.VisibilityGuard.PollInterval,
+		)
 	}
 
 	s.sinkStarted.Store(true)

--- a/pq/replication/stream_gate_test.go
+++ b/pq/replication/stream_gate_test.go
@@ -22,6 +22,7 @@ type gatedStream struct {
 	q        *scriptedQuery
 	m        *countingMetric
 	received []uint32 // xids delivered to the listener
+	commits  []pq.LSN // CommitLSN seen by the listener, in delivery order
 }
 
 func newGatedStream(t *testing.T, cfg config.Config, rows [][]string) *gatedStream {
@@ -30,6 +31,7 @@ func newGatedStream(t *testing.T, cfg config.Config, rows [][]string) *gatedStre
 	gs := &gatedStream{q: &scriptedQuery{rows: rows}}
 	gs.s = NewStream("", cfg, nil, func(ctx *ListenerContext) {
 		gs.received = append(gs.received, ctx.Message.(*format.Insert).XID)
+		gs.commits = append(gs.commits, ctx.CommitLSN)
 		_ = ctx.Ack()
 	}).(*stream)
 	guard, m := testGuard(gs.q.query)
@@ -49,7 +51,7 @@ func (gs *gatedStream) run(msgs ...*Message) error {
 }
 
 func insertMsg(xid uint32, lsn int64) *Message {
-	return &Message{message: &format.Insert{XID: xid, TableName: "books"}, walStart: lsn, xid: xid}
+	return &Message{message: &format.Insert{XID: xid, TableName: "books"}, walStart: lsn, xid: xid, commitLSN: pq.LSN(lsn)}
 }
 
 func guardCfg(mode config.VisibilityFailMode) config.Config {
@@ -139,46 +141,43 @@ func TestGateDisabledDoesNotTouchGuard(t *testing.T) {
 
 	require.NoError(t, gs.run(insertMsg(200, 1)))
 	assert.Equal(t, []uint32{200}, gs.received)
+	assert.Equal(t, []pq.LSN{1}, gs.commits, "ListenerContext.CommitLSN comes from Message.commitLSN")
 	assert.Equal(t, int32(0), gs.q.calls.Load())
 }
 
-func TestDispatchStampsXidOnNonStreamingAndStreamingPaths(t *testing.T) {
+func TestDispatchStampsXidAndCommitLSNOnNonStreamingAndStreamingPaths(t *testing.T) {
 	out := make(chan *Message, 10)
 	s := &stream{}
 	buf := &messageBuffer{outCh: out}
 	streamBuf := &streamTxBuffer{}
 	dispatch := func(msg any, lsn uint64) { s.dispatchMessage(msg, XLogData{WALStart: pq.LSN(lsn)}, buf, streamBuf) }
 
-	// Non-streaming: BEGIN(100) a b COMMIT → both carry 100; the last one is rebuilt by flushWithLSN.
-	dispatch(&format.Begin{Xid: 100}, 1)
+	// Non-streaming: BEGIN(100, final 40) a b COMMIT → both carry xid 100 and commit 40 (from Begin.FinalLSN);
+	// the last one is rebuilt by flushWithLSN.
+	dispatch(&format.Begin{Xid: 100, FinalLSN: 40}, 1)
 	dispatch(&format.Insert{TableName: "a"}, 2)
 	dispatch(&format.Insert{TableName: "b"}, 3)
-	dispatch(&format.Commit{TransactionEndLSN: 50}, 4)
-	// Streaming: STREAM START(200) c(sub 201) d STREAM STOP STREAM COMMIT → both carry the top-level 200.
+	dispatch(&format.Commit{CommitLSN: 40, TransactionEndLSN: 50}, 4)
+	// Streaming: STREAM START(200) c(sub 201) d STREAM STOP STREAM COMMIT(commit 90, end 99) → both carry the
+	// top-level 200 and commit 90, which is only known at STREAM COMMIT.
 	dispatch(&format.StreamStart{Xid: 200}, 5)
 	dispatch(&format.Insert{XID: 201, TableName: "c"}, 6)
 	dispatch(&format.Insert{XID: 200, TableName: "d"}, 7)
 	dispatch(&format.StreamStop{}, 8)
-	dispatch(&format.StreamCommit{Xid: 200, TransactionEndLSN: 99}, 9)
+	dispatch(&format.StreamCommit{Xid: 200, CommitLSN: 90, TransactionEndLSN: 99}, 9)
 	close(out)
 
-	var got []struct {
-		name string
-		xid  uint32
-		lsn  int64
+	type stamped struct {
+		name   string
+		xid    uint32
+		lsn    int64
+		commit pq.LSN
 	}
+	var got []stamped
 	for m := range out {
-		got = append(got, struct {
-			name string
-			xid  uint32
-			lsn  int64
-		}{m.message.(*format.Insert).TableName, m.xid, m.walStart})
+		got = append(got, stamped{m.message.(*format.Insert).TableName, m.xid, m.walStart, m.commitLSN})
 	}
-	assert.Equal(t, []struct {
-		name string
-		xid  uint32
-		lsn  int64
-	}{{"a", 100, 2}, {"b", 100, 50}, {"c", 200, 6}, {"d", 200, 99}}, got)
+	assert.Equal(t, []stamped{{"a", 100, 2, 40}, {"b", 100, 50, 40}, {"c", 200, 6, 90}, {"d", 200, 99, 90}}, got)
 }
 
 func TestCloseCancelsBeforeClosingGuardAndAfterProcessExit(t *testing.T) {

--- a/pq/replication/stream_gate_test.go
+++ b/pq/replication/stream_gate_test.go
@@ -1,0 +1,240 @@
+package replication
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/logger"
+	"github.com/Trendyol/go-pq-cdc/pq"
+	"github.com/Trendyol/go-pq-cdc/pq/message/format"
+	"github.com/Trendyol/go-pq-cdc/pq/publication"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gatedStream wires a stream to a scripted guard and records what the listener saw.
+type gatedStream struct {
+	s        *stream
+	q        *scriptedQuery
+	m        *countingMetric
+	received []uint32 // xids delivered to the listener
+}
+
+func newGatedStream(t *testing.T, cfg config.Config, rows [][]string) *gatedStream {
+	t.Helper()
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+	gs := &gatedStream{q: &scriptedQuery{rows: rows}}
+	gs.s = NewStream("", cfg, nil, func(ctx *ListenerContext) {
+		gs.received = append(gs.received, ctx.Message.(*format.Insert).XID)
+		_ = ctx.Ack()
+	}).(*stream)
+	guard, m := testGuard(gs.q.query)
+	guard.cfg = cfg.VisibilityGuard
+	gs.m = m
+	gs.s.metric = m
+	gs.s.guard = guard
+	return gs
+}
+
+func (gs *gatedStream) run(msgs ...*Message) error {
+	for _, m := range msgs {
+		gs.s.messageCH <- m
+	}
+	close(gs.s.messageCH)
+	return gs.s.processLoop(context.Background())
+}
+
+func insertMsg(xid uint32, lsn int64) *Message {
+	return &Message{message: &format.Insert{XID: xid, TableName: "books"}, walStart: lsn, xid: xid}
+}
+
+func guardCfg(mode config.VisibilityFailMode) config.Config {
+	return config.Config{VisibilityGuard: config.VisibilityGuardConfig{
+		Enabled: true, FailMode: mode, Timeout: 30 * time.Millisecond, PollInterval: time.Millisecond,
+	}}
+}
+
+func TestGateWaitsOncePerTransaction(t *testing.T) {
+	gs := newGatedStream(t, guardCfg(config.VisibilityFailClosed), [][]string{{"f", "100:200:"}, {"f", "100:201:"}})
+	// xid 200 needs two polls; xid 199 is below the cached xmax but not xmin, so it polls once more.
+	require.NoError(t, gs.run(insertMsg(200, 1), insertMsg(200, 2), insertMsg(200, 3), insertMsg(150, 4)))
+
+	assert.Equal(t, []uint32{200, 200, 200, 150}, gs.received)
+	assert.Equal(t, int32(3), gs.q.calls.Load(), "3 messages of xid 200 = 2 polls, xid 150 = 1 poll")
+	assert.Equal(t, pq.LSN(4), gs.s.LoadConfirmedXLogPos())
+}
+
+func TestGateHeartbeatBypass(t *testing.T) {
+	cfg := guardCfg(config.VisibilityFailClosed)
+	cfg.Heartbeat = config.HeartbeatConfig{Table: publication.Table{Schema: "public", Name: "cdc_heartbeat"}}
+	gs := newGatedStream(t, cfg, [][]string{{"f", "100:200:"}})
+	hb := &Message{message: &format.Insert{XID: 300, TableNamespace: "public", TableName: "cdc_heartbeat"}, walStart: 9, xid: 300}
+
+	require.NoError(t, gs.run(hb))
+	assert.Empty(t, gs.received)
+	assert.Equal(t, int32(0), gs.q.calls.Load(), "heartbeat must not poll")
+	assert.Equal(t, pq.LSN(9), gs.s.LoadConfirmedXLogPos(), "heartbeat is still auto-acked")
+}
+
+func TestGateFailClosedTimeoutStopsProcessing(t *testing.T) {
+	gs := newGatedStream(t, guardCfg(config.VisibilityFailClosed), [][]string{{"f", "100:200:"}})
+
+	err := gs.run(insertMsg(200, 1), insertMsg(200, 2))
+	require.ErrorIs(t, err, ErrVisibilityGuard)
+	require.ErrorIs(t, err, ErrVisibilityTimeout)
+	assert.Empty(t, gs.received, "message must be dropped un-dispatched")
+	assert.Equal(t, pq.LSN(0), gs.s.LoadConfirmedXLogPos(), "message must stay un-acked for redelivery")
+	assert.Equal(t, int32(1), gs.m.timeouts.Load())
+	assert.Equal(t, int32(0), gs.m.failOpens.Load())
+}
+
+func TestGateFailOpenTimeoutDispatches(t *testing.T) {
+	gs := newGatedStream(t, guardCfg(config.VisibilityFailOpen), [][]string{{"f", "100:200:"}})
+
+	require.NoError(t, gs.run(insertMsg(200, 1), insertMsg(200, 2)))
+	assert.Equal(t, []uint32{200, 200}, gs.received)
+	assert.Equal(t, int32(1), gs.m.timeouts.Load())
+	assert.Equal(t, int32(1), gs.m.failOpens.Load(), "one fail-open per transaction, not per message")
+}
+
+func TestGateFailOpenStillFailsOnGuardError(t *testing.T) {
+	// pg_is_in_recovery flips mid-stream: failover. Open mode tolerates slow visibility, not a lost primary.
+	gs := newGatedStream(t, guardCfg(config.VisibilityFailOpen), [][]string{{"f", "100:200:"}, {"t", "100:200:"}})
+
+	err := gs.run(insertMsg(200, 1))
+	require.ErrorIs(t, err, ErrVisibilityGuard)
+	require.NotErrorIs(t, err, ErrVisibilityTimeout)
+	assert.Empty(t, gs.received)
+	assert.Equal(t, int32(0), gs.m.failOpens.Load())
+}
+
+func TestGateCancelledMidWaitDropsMessageUndispatched(t *testing.T) {
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+	var delivered int
+	s := NewStream("", guardCfg(config.VisibilityFailOpen), nil, func(*ListenerContext) { delivered++ }).(*stream)
+	guard, m := testGuard(func(ctx context.Context, _ string) ([]string, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	guard.cfg.Timeout = time.Hour
+	s.metric = m
+	s.guard = guard
+	s.messageCH <- insertMsg(200, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(10 * time.Millisecond); cancel() }()
+	require.NoError(t, s.processLoop(ctx))
+	assert.Equal(t, 0, delivered, "an uncertified message must not reach the listener on shutdown")
+	assert.Equal(t, pq.LSN(0), s.LoadConfirmedXLogPos())
+	assert.Equal(t, int32(0), m.failOpens.Load(), "shutdown is not a fail-open")
+}
+
+func TestGateDisabledDoesNotTouchGuard(t *testing.T) {
+	gs := newGatedStream(t, config.Config{}, [][]string{{"f", "100:200:"}})
+	gs.s.guard = nil
+
+	require.NoError(t, gs.run(insertMsg(200, 1)))
+	assert.Equal(t, []uint32{200}, gs.received)
+	assert.Equal(t, int32(0), gs.q.calls.Load())
+}
+
+func TestDispatchStampsXidOnNonStreamingAndStreamingPaths(t *testing.T) {
+	out := make(chan *Message, 10)
+	s := &stream{}
+	buf := &messageBuffer{outCh: out}
+	streamBuf := &streamTxBuffer{}
+	dispatch := func(msg any, lsn uint64) { s.dispatchMessage(msg, XLogData{WALStart: pq.LSN(lsn)}, buf, streamBuf) }
+
+	// Non-streaming: BEGIN(100) a b COMMIT → both carry 100; the last one is rebuilt by flushWithLSN.
+	dispatch(&format.Begin{Xid: 100}, 1)
+	dispatch(&format.Insert{TableName: "a"}, 2)
+	dispatch(&format.Insert{TableName: "b"}, 3)
+	dispatch(&format.Commit{TransactionEndLSN: 50}, 4)
+	// Streaming: STREAM START(200) c(sub 201) d STREAM STOP STREAM COMMIT → both carry the top-level 200.
+	dispatch(&format.StreamStart{Xid: 200}, 5)
+	dispatch(&format.Insert{XID: 201, TableName: "c"}, 6)
+	dispatch(&format.Insert{XID: 200, TableName: "d"}, 7)
+	dispatch(&format.StreamStop{}, 8)
+	dispatch(&format.StreamCommit{Xid: 200, TransactionEndLSN: 99}, 9)
+	close(out)
+
+	var got []struct {
+		name string
+		xid  uint32
+		lsn  int64
+	}
+	for m := range out {
+		got = append(got, struct {
+			name string
+			xid  uint32
+			lsn  int64
+		}{m.message.(*format.Insert).TableName, m.xid, m.walStart})
+	}
+	assert.Equal(t, []struct {
+		name string
+		xid  uint32
+		lsn  int64
+	}{{"a", 100, 2}, {"b", 100, 50}, {"c", 200, 6}, {"d", 200, 99}}, got)
+}
+
+func TestCloseCancelsBeforeClosingGuardAndAfterProcessExit(t *testing.T) {
+	logger.InitLogger(logger.NewSlog(slog.LevelError))
+	var mu sync.Mutex
+	var events []string
+	record := func(e string) { mu.Lock(); events = append(events, e); mu.Unlock() }
+
+	guardConn := &standbyCaptureConn{}
+	blockingQuery := func(ctx context.Context, _ string) ([]string, error) {
+		<-ctx.Done()
+		record("wait-cancelled")
+		return nil, ctx.Err()
+	}
+	s := NewStream("", guardCfg(config.VisibilityFailClosed), nil, func(*ListenerContext) {}).(*stream)
+	guard, m := testGuard(blockingQuery)
+	guard.cfg.Timeout = time.Hour
+	guard.conn = &closeRecorderConn{standbyCaptureConn: guardConn, onClose: func() { record("guard-closed") }}
+	s.metric = m
+	s.guard = guard
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	s.processStarted.Store(true)
+	processDone := make(chan struct{})
+	go func() {
+		s.process(ctx)
+		record("process-exited")
+		close(processDone)
+	}()
+	s.messageCH <- insertMsg(200, 1) // blocks in guard.wait until Close cancels
+
+	time.Sleep(20 * time.Millisecond)
+	done := make(chan error, 1)
+	go func() { done <- s.Close(context.Background()) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked on the guard wait")
+	}
+	<-processDone
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "wait-cancelled", events[0], "context must be cancelled before anything else")
+	assert.Equal(t, "guard-closed", events[len(events)-1], "guard closes only after the process goroutine exited: %v", events)
+	assert.True(t, guardConn.closed)
+}
+
+type closeRecorderConn struct {
+	*standbyCaptureConn
+	onClose func()
+}
+
+func (c *closeRecorderConn) Close(ctx context.Context) error {
+	c.onClose()
+	return c.standbyCaptureConn.Close(ctx)
+}

--- a/pq/replication/visibility.go
+++ b/pq/replication/visibility.go
@@ -1,0 +1,270 @@
+package replication
+
+import (
+	"context"
+	goerrors "errors"
+	"fmt"
+	"math/rand/v2"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/internal/metric"
+	"github.com/Trendyol/go-pq-cdc/pq"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// visibilityGuard holds the first message of every transaction until the
+// transaction's xid is visible to a fresh snapshot on the primary.
+//
+// PostgreSQL flushes the commit record (RecordTransactionCommit → XLogFlush)
+// before the transaction leaves the proc array (ProcArrayEndTransaction), and
+// the logical walsender streams the transaction as soon as the flush wakes it.
+// With synchronous replication SyncRepWaitForLSN also runs in between, so the
+// window is at least the standby ack round-trip. A consumer that reads the
+// primary right after receiving the event can therefore miss the row.
+//
+// The predicate is client-side and epoch-free (docs/visibility-gate-design.md P1):
+// xid is visible iff int32(xid - xmax) < 0 and xid is not in xip, over the
+// low 32 bits of pg_current_snapshot() (txid_current_snapshot() on PG < 13).
+// The guard connection is bound to the replication session: same host, opened
+// after IDENTIFY_SYSTEM, never reconnects; any guard error is a stream error.
+type visibilityGuard struct {
+	conn   pq.Connection
+	query  func(ctx context.Context, sql string) ([]string, error)
+	metric metric.Metric
+	// pollSQL is the per-poll statement; switched to the txid_* variant on PG < 13.
+	pollSQL string
+	cfg     config.VisibilityGuardConfig
+	// xmin of the last parsed snapshot: any xid that precedes it was already
+	// complete when that snapshot was taken and is visible without a query.
+	xmin        uint32
+	hasSnapshot bool
+}
+
+var (
+	// ErrVisibilityGuard is the error class for every guard failure that restarts the stream.
+	ErrVisibilityGuard = goerrors.New("visibility guard unreachable")
+	// ErrVisibilityTimeout reports that a transaction did not become visible within visibilityGuard.timeout.
+	ErrVisibilityTimeout = goerrors.New("visibility guard timeout")
+)
+
+const (
+	// Both checks in one statement: pg_walfile_name ERRORs while in recovery, so
+	// a replica (or a pooler routing to one) fails here with a clear message.
+	visibilityOpenSQL   = "SELECT pg_is_in_recovery(), ('x' || substr(pg_walfile_name(pg_current_wal_lsn()), 1, 8))::bit(32)::int"
+	walSenderTimeoutSQL = "SELECT setting FROM pg_settings WHERE name = 'wal_sender_timeout'" // milliseconds
+	visibilityPollSQL   = "SELECT pg_is_in_recovery(), pg_current_snapshot()::text"           // PostgreSQL 13+
+	legacyPollSQL       = "SELECT pg_is_in_recovery(), txid_current_snapshot()::text"         // PostgreSQL < 13
+	undefinedFunction   = "42883"
+	maxPollInterval     = 250 * time.Millisecond
+)
+
+// openVisibilityGuard dials dsn and runs the mandatory open checks.
+func openVisibilityGuard(ctx context.Context, dsn string, cfg config.VisibilityGuardConfig, timeline int32, m metric.Metric) (*visibilityGuard, error) {
+	conn, err := pq.NewConnection(ctx, dsn)
+	if err != nil {
+		return nil, err
+	}
+	g, err := newVisibilityGuard(ctx, conn, queryRow(conn), cfg, timeline, m)
+	if err != nil {
+		_ = conn.Close(ctx)
+		return nil, err
+	}
+	return g, nil
+}
+
+// newVisibilityGuard verifies the connection is on the primary of the
+// replication session's timeline, that the gate timeout fits under
+// wal_sender_timeout, and that a snapshot function is available.
+func newVisibilityGuard(ctx context.Context, conn pq.Connection, query func(context.Context, string) ([]string, error),
+	cfg config.VisibilityGuardConfig, timeline int32, m metric.Metric,
+) (*visibilityGuard, error) {
+	g := &visibilityGuard{conn: conn, query: query, cfg: cfg, metric: m, pollSQL: visibilityPollSQL}
+
+	row, err := g.query(ctx, visibilityOpenSQL)
+	if err != nil {
+		return nil, fmt.Errorf("primary check (replica or pooler routing?): %w", err)
+	}
+	if len(row) != 2 || row[0] != "f" {
+		return nil, fmt.Errorf("server is in recovery (replica or pooler routing), pg_is_in_recovery=%q", row)
+	}
+	if tl, err := strconv.ParseInt(row[1], 10, 32); err != nil || int32(tl) != timeline {
+		return nil, fmt.Errorf("timeline mismatch: replication session is on %d, guard connection sees %q", timeline, row[1])
+	}
+
+	row, err = g.query(ctx, walSenderTimeoutSQL)
+	if err != nil {
+		return nil, fmt.Errorf("read wal_sender_timeout: %w", err)
+	}
+	ms, err := strconv.ParseInt(strings.Join(row, ""), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parse wal_sender_timeout %q: %w", row, err)
+	}
+	if walSenderTimeout := time.Duration(ms) * time.Millisecond; ms > 0 && cfg.Timeout >= walSenderTimeout/2 {
+		return nil, fmt.Errorf("visibilityGuard.timeout (%s) must be less than half of wal_sender_timeout (%s): "+
+			"keepalive replies stop while the gate blocks", cfg.Timeout, walSenderTimeout)
+	}
+
+	if _, err = g.poll(ctx); err != nil {
+		var pgErr *pgconn.PgError
+		if goerrors.As(err, &pgErr) && pgErr.Code == undefinedFunction {
+			g.pollSQL = legacyPollSQL
+			_, err = g.poll(ctx)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("snapshot probe: %w", err)
+		}
+	}
+	return g, nil
+}
+
+func queryRow(conn pq.Connection) func(context.Context, string) ([]string, error) {
+	return func(ctx context.Context, sql string) ([]string, error) {
+		results, err := conn.Exec(ctx, sql).ReadAll()
+		if err != nil {
+			return nil, err
+		}
+		if len(results) != 1 || len(results[0].Rows) != 1 {
+			return nil, fmt.Errorf("expected exactly one row from %q", sql)
+		}
+		row := make([]string, len(results[0].Rows[0]))
+		for i, col := range results[0].Rows[0] {
+			row[i] = string(col)
+		}
+		return row, nil
+	}
+}
+
+// wait blocks until xid is visible to a new snapshot on the primary. It returns
+// ErrVisibilityTimeout after cfg.Timeout; any other error means the guard can no
+// longer certify visibility and the stream must restart. Errors are never
+// treated as "visible".
+func (g *visibilityGuard) wait(ctx context.Context, xid uint32) error {
+	start := time.Now()
+	defer func() { g.metric.ObserveVisibilityWait(time.Since(start)) }()
+
+	if g.hasSnapshot && xidPrecedes(xid, g.xmin) {
+		return nil
+	}
+
+	deadline := start.Add(g.cfg.Timeout)
+	delay := g.cfg.PollInterval
+	for {
+		snap, err := g.poll(ctx)
+		if err != nil {
+			return err
+		}
+		if snap.visible(xid) {
+			return nil
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			g.metric.VisibilityTimeoutIncrement()
+			return fmt.Errorf("%w: xid %d not visible after %s", ErrVisibilityTimeout, xid, g.cfg.Timeout)
+		}
+		sleep := delay + rand.N(delay/2+1) //nolint:gosec // jitter only
+		if sleep > remaining {
+			sleep = remaining
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(sleep):
+		}
+		if delay *= 2; delay > maxPollInterval {
+			delay = maxPollInterval
+		}
+	}
+}
+
+func (g *visibilityGuard) poll(ctx context.Context) (pgSnapshot, error) {
+	if err := ctx.Err(); err != nil {
+		return pgSnapshot{}, err // shutting down: do not touch the connection Close is about to close
+	}
+	// A single poll slower than the gate timeout means the guard is broken.
+	// pgconn closes the connection when the deadline cuts a query, which is
+	// what we want: the guard never reconnects, the stream restarts.
+	queryCtx, cancel := context.WithTimeout(ctx, g.cfg.Timeout)
+	defer cancel()
+
+	row, err := g.query(queryCtx, g.pollSQL)
+	if err != nil {
+		return pgSnapshot{}, err
+	}
+	if len(row) != 2 || (row[0] != "f" && row[0] != "t") {
+		return pgSnapshot{}, fmt.Errorf("malformed poll result %q", row)
+	}
+	if row[0] == "t" {
+		return pgSnapshot{}, goerrors.New("primary went into recovery (failover?)")
+	}
+	snap, err := parseSnapshot(row[1])
+	if err != nil {
+		return pgSnapshot{}, err
+	}
+	g.xmin, g.hasSnapshot = snap.xmin, true
+	return snap, nil
+}
+
+func (g *visibilityGuard) close(ctx context.Context) error {
+	return g.conn.Close(ctx)
+}
+
+// pgSnapshot is the low 32 bits of a pg_snapshot / txid_snapshot text value.
+type pgSnapshot struct {
+	xip  []uint32
+	xmin uint32
+	xmax uint32
+}
+
+// parseSnapshot parses "xmin:xmax:xip1,xip2,..." (64-bit values, low 32 bits kept).
+func parseSnapshot(s string) (pgSnapshot, error) {
+	parts := strings.Split(s, ":")
+	if len(parts) != 3 {
+		return pgSnapshot{}, fmt.Errorf("malformed snapshot %q", s)
+	}
+	var snap pgSnapshot
+	var err error
+	if snap.xmin, err = parseXid(parts[0]); err != nil {
+		return pgSnapshot{}, fmt.Errorf("malformed snapshot xmin %q: %w", s, err)
+	}
+	if snap.xmax, err = parseXid(parts[1]); err != nil {
+		return pgSnapshot{}, fmt.Errorf("malformed snapshot xmax %q: %w", s, err)
+	}
+	if parts[2] != "" {
+		for _, x := range strings.Split(parts[2], ",") {
+			xid, err := parseXid(x)
+			if err != nil {
+				return pgSnapshot{}, fmt.Errorf("malformed snapshot xip %q: %w", s, err)
+			}
+			snap.xip = append(snap.xip, xid)
+		}
+	}
+	return snap, nil
+}
+
+func parseXid(s string) (uint32, error) {
+	v, err := strconv.ParseUint(s, 10, 64)
+	return uint32(v), err
+}
+
+// visible applies PostgreSQL's own rule: everything at or past xmax is
+// invisible (xmax = latestCompletedXid + 1, so inside the commit gap xid >= xmax),
+// everything below xmax is visible unless it is still in progress (xip).
+func (s pgSnapshot) visible(xid uint32) bool {
+	if !xidPrecedes(xid, s.xmax) {
+		return false
+	}
+	for _, x := range s.xip {
+		if x == xid {
+			return false
+		}
+	}
+	return true
+}
+
+// xidPrecedes is TransactionIdPrecedes: modular 32-bit compare, valid within 2^31.
+func xidPrecedes(a, b uint32) bool {
+	return int32(a-b) < 0
+}

--- a/pq/replication/visibility.go
+++ b/pq/replication/visibility.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Trendyol/go-pq-cdc/config"
 	"github.com/Trendyol/go-pq-cdc/internal/metric"
+	"github.com/Trendyol/go-pq-cdc/logger"
 	"github.com/Trendyol/go-pq-cdc/pq"
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -143,7 +144,14 @@ func queryRow(conn pq.Connection) func(context.Context, string) ([]string, error
 // treated as "visible".
 func (g *visibilityGuard) wait(ctx context.Context, xid uint32) error {
 	start := time.Now()
-	defer func() { g.metric.ObserveVisibilityWait(time.Since(start)) }()
+	polled := false
+	defer func() {
+		waited := time.Since(start)
+		g.metric.ObserveVisibilityWait(waited)
+		if polled {
+			logger.Info("visibility guard wait completed", "xid", xid, "duration", waited)
+		}
+	}()
 
 	if g.hasSnapshot && xidPrecedes(xid, g.xmin) {
 		return nil
@@ -152,6 +160,7 @@ func (g *visibilityGuard) wait(ctx context.Context, xid uint32) error {
 	deadline := start.Add(g.cfg.Timeout)
 	delay := g.cfg.PollInterval
 	for {
+		polled = true
 		snap, err := g.poll(ctx)
 		if err != nil {
 			return err

--- a/pq/replication/visibility.go
+++ b/pq/replication/visibility.go
@@ -60,6 +60,7 @@ const (
 	legacyPollSQL       = "SELECT pg_is_in_recovery(), txid_current_snapshot()::text"         // PostgreSQL < 13
 	undefinedFunction   = "42883"
 	maxPollInterval     = 250 * time.Millisecond
+	slowVisibilityWait  = 100 * time.Millisecond
 )
 
 // openVisibilityGuard dials dsn and runs the mandatory open checks.
@@ -142,14 +143,21 @@ func queryRow(conn pq.Connection) func(context.Context, string) ([]string, error
 // ErrVisibilityTimeout after cfg.Timeout; any other error means the guard can no
 // longer certify visibility and the stream must restart. Errors are never
 // treated as "visible".
-func (g *visibilityGuard) wait(ctx context.Context, xid uint32) error {
+func (g *visibilityGuard) wait(ctx context.Context, xid uint32) (err error) {
 	start := time.Now()
-	polled := false
+	pollCount := 0
 	defer func() {
 		waited := time.Since(start)
 		g.metric.ObserveVisibilityWait(waited)
-		if polled {
-			logger.Info("visibility guard wait completed", "xid", xid, "duration", waited)
+		if err != nil || pollCount == 0 {
+			return
+		}
+
+		args := []any{"xid", xid, "wait_ms", float64(waited.Microseconds()) / 1000, "poll_count", pollCount}
+		if waited >= slowVisibilityWait {
+			logger.Info("visibility guard slow wait completed", args...)
+		} else {
+			logger.Debug("visibility guard wait completed", args...)
 		}
 	}()
 
@@ -160,7 +168,7 @@ func (g *visibilityGuard) wait(ctx context.Context, xid uint32) error {
 	deadline := start.Add(g.cfg.Timeout)
 	delay := g.cfg.PollInterval
 	for {
-		polled = true
+		pollCount++
 		snap, err := g.poll(ctx)
 		if err != nil {
 			return err

--- a/pq/replication/visibility_test.go
+++ b/pq/replication/visibility_test.go
@@ -1,0 +1,225 @@
+package replication
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/internal/metric"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotVisible(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot string
+		xid      uint32
+		visible  bool
+	}{
+		{name: "below xmin", snapshot: "100:200:150", xid: 50, visible: true},
+		{name: "equal to xmin, not in xip", snapshot: "100:200:", xid: 100, visible: true},
+		{name: "in xip (in progress)", snapshot: "100:200:150,160", xid: 150, visible: false},
+		{name: "between xmin and xmax, not in xip", snapshot: "100:200:150", xid: 160, visible: true},
+		{name: "equal to xmax (inside the commit gap)", snapshot: "100:200:", xid: 200, visible: false},
+		{name: "above xmax", snapshot: "100:200:", xid: 250, visible: false},
+		{name: "empty xip", snapshot: "100:200:", xid: 150, visible: true},
+		// xid8 values carry the epoch; only the low 32 bits are compared.
+		{name: "epoch 1 snapshot, xid committed", snapshot: "4294967390:4294967496:4294967400", xid: 150, visible: true},
+		{name: "epoch 1 snapshot, xid in xip", snapshot: "4294967390:4294967496:4294967400", xid: 104, visible: false},
+		{name: "epoch 1 snapshot, xid at xmax", snapshot: "4294967390:4294967496:", xid: 200, visible: false},
+		// Wraparound at the 2^32 boundary: xmax just wrapped to 5, an old xid near 2^32 precedes it.
+		{name: "wraparound: old xid precedes wrapped xmax", snapshot: "4294967290:4294967301:", xid: 4294967295, visible: true},
+		{name: "wraparound: old xid still in xip", snapshot: "4294967290:4294967301:4294967295", xid: 4294967295, visible: false},
+		{name: "wraparound: xid just below wrapped xmax", snapshot: "4294967290:4294967301:", xid: 3, visible: true},
+		{name: "wraparound: xid at wrapped xmax", snapshot: "4294967290:4294967301:", xid: 5, visible: false},
+		{name: "wraparound: xid far ahead is not visible", snapshot: "4294967290:4294967301:", xid: 2_000_000_000, visible: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snap, err := parseSnapshot(tt.snapshot)
+			require.NoError(t, err)
+			assert.Equal(t, tt.visible, snap.visible(tt.xid))
+		})
+	}
+}
+
+func TestParseSnapshotMalformed(t *testing.T) {
+	for _, s := range []string{"", "garbage", "100:200", "100:200:150:1", "a:200:", "100:b:", "100:200:abc", "100:200:150,"} {
+		_, err := parseSnapshot(s)
+		assert.Error(t, err, s)
+	}
+}
+
+// scriptedQuery returns one canned poll row per call; the last row repeats.
+type scriptedQuery struct {
+	rows  [][]string
+	calls atomic.Int32
+}
+
+func (q *scriptedQuery) query(_ context.Context, _ string) ([]string, error) {
+	n := int(q.calls.Add(1)) - 1
+	if n >= len(q.rows) {
+		n = len(q.rows) - 1
+	}
+	return q.rows[n], nil
+}
+
+type countingMetric struct {
+	metric.Metric
+	timeouts  atomic.Int32
+	failOpens atomic.Int32
+}
+
+func (m *countingMetric) VisibilityTimeoutIncrement()  { m.timeouts.Add(1) }
+func (m *countingMetric) VisibilityFailOpenIncrement() { m.failOpens.Add(1) }
+
+func testGuard(query func(context.Context, string) ([]string, error)) (*visibilityGuard, *countingMetric) {
+	m := &countingMetric{Metric: metric.NewMetric("test_slot")}
+	return &visibilityGuard{
+		conn:    &standbyCaptureConn{},
+		query:   query,
+		metric:  m,
+		pollSQL: visibilityPollSQL,
+		cfg:     config.VisibilityGuardConfig{Enabled: true, FailMode: config.VisibilityFailClosed, Timeout: 50 * time.Millisecond, PollInterval: time.Millisecond},
+	}, m
+}
+
+func TestGuardWaitPollsUntilVisible(t *testing.T) {
+	q := &scriptedQuery{rows: [][]string{{"f", "100:200:"}, {"f", "100:200:"}, {"f", "100:201:"}}}
+	g, m := testGuard(q.query)
+
+	require.NoError(t, g.wait(context.Background(), 200))
+	assert.Equal(t, int32(3), q.calls.Load())
+	assert.Equal(t, int32(0), m.timeouts.Load())
+}
+
+func TestGuardWaitUsesCachedXmin(t *testing.T) {
+	q := &scriptedQuery{rows: [][]string{{"f", "100:200:"}}}
+	g, _ := testGuard(q.query)
+
+	require.NoError(t, g.wait(context.Background(), 150)) // poll, caches xmin=100
+	require.NoError(t, g.wait(context.Background(), 99))  // below cached xmin: no query
+	assert.Equal(t, int32(1), q.calls.Load())
+
+	require.NoError(t, g.wait(context.Background(), 100)) // at xmin: needs a fresh poll
+	assert.Equal(t, int32(2), q.calls.Load())
+}
+
+func TestGuardWaitNoCacheBeforeFirstPoll(t *testing.T) {
+	q := &scriptedQuery{rows: [][]string{{"f", "100:200:"}}}
+	g, _ := testGuard(q.query)
+
+	// Without a snapshot, an xid in the upper half must not "precede" xmin=0.
+	require.NoError(t, g.wait(context.Background(), 150))
+	assert.Equal(t, int32(1), q.calls.Load())
+}
+
+func TestGuardWaitTimeout(t *testing.T) {
+	q := &scriptedQuery{rows: [][]string{{"f", "100:200:"}}}
+	g, m := testGuard(q.query)
+
+	err := g.wait(context.Background(), 200)
+	require.ErrorIs(t, err, ErrVisibilityTimeout)
+	assert.Equal(t, int32(1), m.timeouts.Load())
+	assert.Greater(t, q.calls.Load(), int32(1), "must keep polling until the deadline")
+}
+
+func TestGuardWaitRecoveryFlipIsAnError(t *testing.T) {
+	q := &scriptedQuery{rows: [][]string{{"f", "100:200:"}, {"t", "100:200:"}}}
+	g, m := testGuard(q.query)
+
+	err := g.wait(context.Background(), 200)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrVisibilityTimeout)
+	assert.Equal(t, int32(0), m.timeouts.Load())
+}
+
+func TestGuardWaitMalformedIsAnError(t *testing.T) {
+	for _, row := range [][]string{{"f", "garbage"}, {"maybe", "100:200:"}, {"f"}, {}} {
+		q := &scriptedQuery{rows: [][]string{row}}
+		g, _ := testGuard(q.query)
+		err := g.wait(context.Background(), 150)
+		require.Error(t, err, row)
+		require.NotErrorIs(t, err, ErrVisibilityTimeout)
+	}
+}
+
+func TestGuardWaitQueryErrorIsAnError(t *testing.T) {
+	boom := errors.New("connection reset")
+	g, _ := testGuard(func(context.Context, string) ([]string, error) { return nil, boom })
+	require.ErrorIs(t, g.wait(context.Background(), 150), boom)
+}
+
+func TestGuardWaitReturnsOnContextCancel(t *testing.T) {
+	q := &scriptedQuery{rows: [][]string{{"f", "100:200:"}}}
+	g, _ := testGuard(q.query)
+	g.cfg.Timeout = time.Hour
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(10 * time.Millisecond); cancel() }()
+
+	require.ErrorIs(t, g.wait(ctx, 200), context.Canceled)
+}
+
+// openScript answers the open-time statements by SQL text.
+func openScript(recovery, timeline, walSenderTimeout string, pollErr error, pollRow []string) func(context.Context, string) ([]string, error) {
+	return func(_ context.Context, sql string) ([]string, error) {
+		switch sql {
+		case visibilityOpenSQL:
+			if recovery == "t" {
+				return nil, &pgconn.PgError{Code: "55000", Message: "recovery is in progress"}
+			}
+			return []string{recovery, timeline}, nil
+		case walSenderTimeoutSQL:
+			return []string{walSenderTimeout}, nil
+		case visibilityPollSQL:
+			if pollErr != nil {
+				return nil, pollErr
+			}
+			return pollRow, nil
+		case legacyPollSQL:
+			return pollRow, nil
+		}
+		return nil, errors.New("unexpected statement: " + sql)
+	}
+}
+
+func TestNewVisibilityGuardOpenChecks(t *testing.T) {
+	cfg := config.VisibilityGuardConfig{Enabled: true, FailMode: config.VisibilityFailClosed, Timeout: 10 * time.Second, PollInterval: 5 * time.Millisecond}
+	okRow := []string{"f", "100:200:"}
+	undefined := &pgconn.PgError{Code: undefinedFunction, Message: "function pg_current_snapshot() does not exist"}
+
+	tests := []struct {
+		query   func(context.Context, string) ([]string, error)
+		name    string
+		wantErr string
+		cfg     config.VisibilityGuardConfig
+		legacy  bool
+	}{
+		{name: "primary on the right timeline", query: openScript("f", "7", "60000", nil, okRow), cfg: cfg},
+		{name: "wal_sender_timeout disabled skips the ratio check", query: openScript("f", "7", "0", nil, okRow), cfg: cfg},
+		{name: "in recovery", query: openScript("t", "7", "60000", nil, okRow), cfg: cfg, wantErr: "recovery"},
+		{name: "timeline mismatch", query: openScript("f", "8", "60000", nil, okRow), cfg: cfg, wantErr: "timeline mismatch"},
+		{name: "timeout >= wal_sender_timeout/2", query: openScript("f", "7", "20000", nil, okRow), cfg: cfg, wantErr: "wal_sender_timeout"},
+		{name: "timeout just under wal_sender_timeout/2", query: openScript("f", "7", "20001", nil, okRow), cfg: cfg},
+		{name: "PG < 13 falls back to txid_current_snapshot", query: openScript("f", "7", "60000", undefined, okRow), cfg: cfg, legacy: true},
+		{name: "snapshot probe error", query: openScript("f", "7", "60000", errors.New("boom"), okRow), cfg: cfg, wantErr: "snapshot probe"},
+		{name: "snapshot probe malformed", query: openScript("f", "7", "60000", nil, []string{"f", "bad"}), cfg: cfg, wantErr: "snapshot probe"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g, err := newVisibilityGuard(context.Background(), &standbyCaptureConn{}, tt.query, tt.cfg, 7, metric.NewMetric("test_slot"))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.legacy, g.pollSQL == legacyPollSQL)
+			assert.True(t, g.hasSnapshot, "open probe must prime the snapshot cache")
+		})
+	}
+}

--- a/pq/slot/config.go
+++ b/pq/slot/config.go
@@ -14,6 +14,10 @@ type Config struct {
 	//   2 – requires PostgreSQL 14+; supports streaming large in-progress transactions (default).
 	ProtoVersion      int  `json:"protoVersion" yaml:"protoVersion"`
 	CreateIfNotExists bool `json:"createIfNotExists" yaml:"createIfNotExists"`
+	// Failover creates the slot with FAILOVER true (PostgreSQL 17+) so standbys
+	// running sync_replication_slots keep a synchronized copy; an existing slot
+	// is altered. Rejected with a clear error on older servers.
+	Failover bool `json:"failover" yaml:"failover"`
 }
 
 func (c Config) Validate() error {

--- a/pq/slot/slot.go
+++ b/pq/slot/slot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -23,6 +24,10 @@ var (
 )
 
 var typeMap = pgtype.NewMap()
+
+// failoverMinServerVersion is the first server_version_num with
+// CREATE_REPLICATION_SLOT ... (FAILOVER true) and ALTER_REPLICATION_SLOT.
+const failoverMinServerVersion = 170000
 
 type XLogUpdater interface {
 	UpdateXLogPos(l pq.LSN)
@@ -71,6 +76,12 @@ func (s *Slot) Create(ctx context.Context) (*Info, error) {
 		_ = s.conn.Close(ctx)
 	}()
 
+	if s.cfg.Failover {
+		if err := s.checkFailoverSupportLocked(ctx); err != nil {
+			return nil, err
+		}
+	}
+
 	info, err := s.infoLocked(ctx)
 	if err != nil {
 		if !goerrors.Is(err, ErrorSlotIsNotExists) || !s.cfg.CreateIfNotExists {
@@ -78,20 +89,85 @@ func (s *Slot) Create(ctx context.Context) (*Info, error) {
 		}
 	} else {
 		logger.Warn("replication slot already exists")
+		if s.cfg.Failover {
+			if err := s.enableFailoverLocked(ctx, info); err != nil {
+				return nil, err
+			}
+		}
 		return info, nil
 	}
 
 	// Slot needs replication connection for CREATE_REPLICATION_SLOT command
-	if err := s.createSlotWithReplicationConn(ctx); err != nil {
-		return nil, err
+	sql := fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL pgoutput", s.cfg.Name)
+	if s.cfg.Failover {
+		sql += " (FAILOVER true)"
+	}
+	if err := s.execReplicationCommand(ctx, sql); err != nil {
+		return nil, errors.Wrap(err, "replication slot create")
 	}
 
-	logger.Info("replication slot created", "name", s.cfg.Name)
+	logger.Info("replication slot created", "name", s.cfg.Name, "failover", s.cfg.Failover)
 
 	return s.infoLocked(ctx)
 }
 
-func (s *Slot) createSlotWithReplicationConn(ctx context.Context) error {
+// checkFailoverSupportLocked rejects slot.failover on servers older than 17
+// with a clear error instead of a CREATE_REPLICATION_SLOT syntax error.
+func (s *Slot) checkFailoverSupportLocked(ctx context.Context) error {
+	raw, err := s.scalarLocked(ctx, "SHOW server_version_num")
+	if err != nil {
+		return errors.Wrap(err, "server version")
+	}
+	version, err := strconv.Atoi(raw)
+	if err != nil {
+		return errors.Wrapf(err, "server version %q", raw)
+	}
+	if version < failoverMinServerVersion {
+		return errors.Newf("slot.failover requires PostgreSQL 17 or newer (server_version_num %d)", version)
+	}
+	return nil
+}
+
+// enableFailoverLocked turns FAILOVER on for an existing slot created without
+// it. ALTER_REPLICATION_SLOT needs the slot to be free: while another
+// walsender holds it (rolling deployment) the ALTER is skipped with a warning
+// and retried by the next Create.
+func (s *Slot) enableFailoverLocked(ctx context.Context, info *Info) error {
+	failover, err := s.scalarLocked(ctx, fmt.Sprintf("SELECT failover FROM pg_replication_slots WHERE slot_name = '%s'", s.cfg.Name))
+	if err != nil {
+		return errors.Wrap(err, "replication slot failover flag")
+	}
+	if failover == "t" {
+		return nil
+	}
+	if info.Active {
+		logger.Warn("replication slot is active for another process, failover will be enabled once it is released", "name", s.cfg.Name, "activePID", info.ActivePID)
+		return nil
+	}
+	if err := s.execReplicationCommand(ctx, fmt.Sprintf("ALTER_REPLICATION_SLOT %s (FAILOVER true)", s.cfg.Name)); err != nil {
+		return errors.Wrap(err, "replication slot enable failover")
+	}
+	logger.Info("replication slot failover enabled", "name", s.cfg.Name)
+	return nil
+}
+
+// scalarLocked runs sql on the regular connection and returns the first
+// column of the first row as text.
+func (s *Slot) scalarLocked(ctx context.Context, sql string) (string, error) {
+	results, err := s.conn.Exec(ctx, sql).ReadAll()
+	if err != nil {
+		return "", err
+	}
+	if len(results) == 0 || len(results[0].Rows) == 0 || len(results[0].Rows[0]) == 0 {
+		return "", errors.Newf("no rows: %s", sql)
+	}
+	return string(results[0].Rows[0][0]), nil
+}
+
+// execReplicationCommand runs a replication-protocol command
+// (CREATE_REPLICATION_SLOT, ALTER_REPLICATION_SLOT) on a short-lived
+// replication connection.
+func (s *Slot) execReplicationCommand(ctx context.Context, sql string) error {
 	if err := s.replicationConn.Connect(ctx); err != nil {
 		return errors.Wrap(err, "slot replication connect")
 	}
@@ -99,17 +175,13 @@ func (s *Slot) createSlotWithReplicationConn(ctx context.Context) error {
 		_ = s.replicationConn.Close(ctx)
 	}()
 
-	sql := fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL pgoutput", s.cfg.Name)
 	resultReader := s.replicationConn.Exec(ctx, sql)
-	_, err := resultReader.ReadAll()
-	if err != nil {
-		return errors.Wrap(err, "replication slot create result")
+	if _, err := resultReader.ReadAll(); err != nil {
+		return errors.Wrap(err, "result")
 	}
-
-	if err = resultReader.Close(); err != nil {
-		return errors.Wrap(err, "replication slot create result reader close")
+	if err := resultReader.Close(); err != nil {
+		return errors.Wrap(err, "result reader close")
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
- **fix(stream): keep committed rows on sub-transaction STREAM ABORT**
- **feat(stream): opt-in visibility gate for logical-decoding read-after-write**
- **feat(stream): expose CommitLSN on every delivered message**
- **feat(slot): opt-in failover slots (PostgreSQL 17+)**
- **ci(integration): add PostgreSQL 17 to the matrix**
- **docs(readme): visibility guard mechanism, guarantee limits, sync-rep corollary**
- **chore: add logging**
- **chore: add logging v2**
- **chore: add example for visibility guard**
